### PR TITLE
Support gzip for in scope bulk upload apps

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### Version 1.1.9
+- Added support for Genbank *.gb and *.gbff extensions
+- Added support for gzipped Reads, Assemblies, Genbank Files, and GFF files.
+
 ### Version 1.1.8
 - Added new endpoint `importer-mappings/` for getting a mapping of importers for file names
 - Updated endpoint to use GET and query_string

--- a/deployment/conf/supported_apps_w_extensions.json
+++ b/deployment/conf/supported_apps_w_extensions.json
@@ -23,7 +23,11 @@
       ],
       "extensions": [
         "fq",
-        "fastq"
+        "fq.gz",
+        "fq.gzip",
+        "fastq",
+        "fastq.gz",
+        "fastq.gzip"
       ],
       "_id": 1
     },
@@ -37,7 +41,11 @@
       ],
       "extensions": [
         "fq",
-        "fastq"
+        "fq.gz",
+        "fq.gzip",
+        "fastq",
+        "fastq.gz",
+        "fastq.gzip"
       ],
       "_id": 2
     },
@@ -50,10 +58,20 @@
       ],
       "extensions": [
         "fna",
+        "fna.gz",
+        "fna.gzip",
         "fa",
+        "fa.gz",
+        "fa.gzip",
         "faa",
+        "faa.gz",
+        "faa.gzip",
         "fsa",
-        "fasta"
+        "fsa.gz",
+        "fsa.gzip",
+        "fasta",
+        "fasta.gz",
+        "fasta.gzip"
       ],
       "_id": 3
     },
@@ -66,13 +84,29 @@
       ],
       "extensions": [
         "fna",
+        "fna.gz",
+        "fna.gzip",
         "fa",
+        "fa.gz",
+        "fa.gzip",
         "faa",
+        "faa.gz",
+        "faa.gzip",
         "fsa",
+        "fsa.gz",
+        "fsa.gzip",
         "fasta",
+        "fasta.gz",
+        "fasta.gzip",
         "gff",
+        "gff.gz",
+        "gff.gzip",
         "gff2",
-        "gff3"
+        "gff2.gz",
+        "gff2.gzip",
+        "gff3",
+        "gff3.gz",
+        "gff3.gzip"
       ],
       "_id": 4
     },
@@ -85,13 +119,29 @@
       ],
       "extensions": [
         "fna",
+        "fna.gz",
+        "fna.gzip",
         "fa",
+        "fa.gz",
+        "fa.gzip",
         "faa",
+        "faa.gz",
+        "faa.gzip",
         "fsa",
+        "fsa.gz",
+        "fsa.gzip",
         "fasta",
+        "fasta.gz",
+        "fasta.gzip",
         "gff",
+        "gff.gz",
+        "gff.gzip",
         "gff2",
-        "gff3"
+        "gff2.gz",
+        "gff2.gzip",
+        "gff3",
+        "gff3.gz",
+        "gff3.gzip"
       ],
       "_id": 5
     },
@@ -104,9 +154,17 @@
       ],
       "extensions": [
         "gb",
+        "gb.gz",
+        "gb.gzip",
         "gbff",
+        "gbff.gz",
+        "gbff.gzip",
         "gbk",
-        "genbank"
+        "gbk.gz",
+        "gbk.gzip",
+        "genbank",
+        "genbank.gz",
+        "genbank.gzip"
       ],
       "_id": 6
     },
@@ -266,6 +324,30 @@
         "app_weight": 1
       }
     ],
+    "fq.gz": [
+      {
+        "id": "fastq_reads_interleaved",
+        "title": "FastQ Reads Interleaved",
+        "app_weight": 1
+      },
+      {
+        "id": "fastq_reads_noninterleaved",
+        "title": "FastQ Reads NonInterleaved",
+        "app_weight": 1
+      }
+    ],
+    "fq.gzip": [
+      {
+        "id": "fastq_reads_interleaved",
+        "title": "FastQ Reads Interleaved",
+        "app_weight": 1
+      },
+      {
+        "id": "fastq_reads_noninterleaved",
+        "title": "FastQ Reads NonInterleaved",
+        "app_weight": 1
+      }
+    ],
     "fastq": [
       {
         "id": "fastq_reads_interleaved",
@@ -278,7 +360,65 @@
         "app_weight": 1
       }
     ],
+    "fastq.gz": [
+      {
+        "id": "fastq_reads_interleaved",
+        "title": "FastQ Reads Interleaved",
+        "app_weight": 1
+      },
+      {
+        "id": "fastq_reads_noninterleaved",
+        "title": "FastQ Reads NonInterleaved",
+        "app_weight": 1
+      }
+    ],
+    "fastq.gzip": [
+      {
+        "id": "fastq_reads_interleaved",
+        "title": "FastQ Reads Interleaved",
+        "app_weight": 1
+      },
+      {
+        "id": "fastq_reads_noninterleaved",
+        "title": "FastQ Reads NonInterleaved",
+        "app_weight": 1
+      }
+    ],
     "fna": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "fna.gz": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "fna.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
@@ -312,7 +452,75 @@
         "app_weight": 1
       }
     ],
+    "fa.gz": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "fa.gzip": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
     "faa": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "faa.gz": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "faa.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
@@ -346,7 +554,75 @@
         "app_weight": 1
       }
     ],
+    "fsa.gz": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "fsa.gzip": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
     "fasta": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "fasta.gz": [
+      {
+        "id": "assembly",
+        "title": "Assembly",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "fasta.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
@@ -375,7 +651,55 @@
         "app_weight": 1
       }
     ],
+    "gff.gz": [
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "gff.gzip": [
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
     "gff2": [
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "gff2.gz": [
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "gff2.gzip": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
@@ -399,7 +723,45 @@
         "app_weight": 1
       }
     ],
+    "gff3.gz": [
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
+    "gff3.gzip": [
+      {
+        "id": "gff_genome",
+        "title": "GFF/FASTA Genome",
+        "app_weight": 1
+      },
+      {
+        "id": "gff_metagenome",
+        "title": "GFF/FASTA MetaGenome",
+        "app_weight": 1
+      }
+    ],
     "gb": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
+    "gb.gz": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
+    "gb.gzip": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
@@ -413,6 +775,20 @@
         "app_weight": 1
       }
     ],
+    "gbff.gz": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
+    "gbff.gzip": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
     "gbk": [
       {
         "id": "genbank_genome",
@@ -420,7 +796,35 @@
         "app_weight": 1
       }
     ],
+    "gbk.gz": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
+    "gbk.gzip": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
     "genbank": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
+    "genbank.gz": [
+      {
+        "id": "genbank_genome",
+        "title": "Genbank Genome",
+        "app_weight": 1
+      }
+    ],
+    "genbank.gzip": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",

--- a/staging_service/AutoDetectUtils.py
+++ b/staging_service/AutoDetectUtils.py
@@ -12,15 +12,19 @@ class AutoDetectUtils:
     @staticmethod
     def determine_possible_importers(filename: str) -> Optional[list]:
         """
-        Given a filename, come up with a reference to all possible apps
+        Given a filename, come up with a reference to all possible apps.
         :param filename: The filename to find applicable apps for
         :return: A list of mapping references, or None if not found
         """
-        if "." in filename:
-            suffix = filename.split(".")[-1].lower()
-            return AutoDetectUtils._MAPPINGS["types"].get(suffix)
-        else:
-            return None
+        dotcount = filename.count(".")
+        if dotcount:
+            # preferentially choose the most specific suffix (e.g. longest)
+            # to get file type mappings
+            for i in range(1, dotcount + 1):
+                suffix = filename.split(".", i)[-1].lower()
+                if suffix in AutoDetectUtils._MAPPINGS["types"]:
+                    return AutoDetectUtils._MAPPINGS["types"][suffix]
+        return None
 
     @staticmethod
     def get_mappings(file_list: list) -> dict:

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -15,7 +15,7 @@ from .metadata import some_metadata, dir_info, add_upa, similar
 from .utils import Path, run_command, AclManager
 
 routes = web.RouteTableDef()
-VERSION = "1.1.8"
+VERSION = "1.1.9"
 
 
 @routes.get("/importer_mappings/{query:.*}")

--- a/staging_service/autodetect/Mappings.py
+++ b/staging_service/autodetect/Mappings.py
@@ -50,13 +50,27 @@ metabolic_annotations_bulk_id = "metabolic_annotation_bulk"
 attribute_mapping_id = "attribute_mapping"
 escher_map_id = "escher_map"
 
+def _flatten(some_list):
+    # you can do this in a 1 line comprehension but it's unreadable
+    flat_list = []
+    for sublist in some_list:
+        for item in sublist:
+            flat_list.append(item)
+    return flat_list
+
+_GZIP_EXT = ["", ".gz", ".gzip"]  # empty string to keep the uncompressed extension
+
+# longer term there's probably a better way to do this but this is quick
+def _add_gzip(extension_list):
+    return _flatten([[ext + gz for gz in _GZIP_EXT] for ext in extension_list])
+
 type_to_extension_mapping = {
-    FASTA: ["fna", "fa", "faa", "fsa", "fasta"],
-    FASTQ: ["fq", "fastq"],
-    GFF: ["gff", "gff2", "gff3"],
+    FASTA: _add_gzip(["fna", "fa", "faa", "fsa", "fasta"]),
+    FASTQ: _add_gzip(["fq", "fastq"]),
+    GFF: _add_gzip(["gff", "gff2", "gff3"]),
     # GTF: ["gtf"],
-    SRA: ["sra"],
-    GENBANK: ["gb", "gbff", "gbk", "genbank"],
+    SRA: ["sra"],  # SRA files are already compressed
+    GENBANK: _add_gzip(["gb", "gbff", "gbk", "genbank"]),
     # SAM: ["sam"],
     # VCF: ["vcf"],
     # MSA: [

--- a/staging_service/autodetect/Mappings.py
+++ b/staging_service/autodetect/Mappings.py
@@ -1,3 +1,5 @@
+import itertools
+
 # Regular Formats
 JSON = "JSON"
 TSV = "TSV"
@@ -51,12 +53,7 @@ attribute_mapping_id = "attribute_mapping"
 escher_map_id = "escher_map"
 
 def _flatten(some_list):
-    # you can do this in a 1 line comprehension but it's unreadable
-    flat_list = []
-    for sublist in some_list:
-        for item in sublist:
-            flat_list.append(item)
-    return flat_list
+    return list(itertools.chain.from_iterable(some_list))
 
 _GZIP_EXT = ["", ".gz", ".gzip"]  # empty string to keep the uncompressed extension
 


### PR DESCRIPTION
Without doing a lot of restructuring of the app specs and autodetection logic, it seems to me the best way to handle gzipped files that we know are supported by apps is to preferentially pick the longest valid extension to get importers. This means that `*.gb.gz` will autodetect to Genbank rather than have Genbank and Decompress suggested.

It's a bit fragile if we start getting extensions with lots of dots in them, but that doesn't seem very likely.

The user can always pick Decompress from the dropdown if they wish.

416/473 lines are autogenerated.