### PR TITLE
Minor code & docs cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,10 +772,10 @@ Response:
 			"app": "kb_uploadmethods/unpack_staging_file",
 			"output_type": [null],
 			"extensions": ["zip", "tar", "tgz", "tar.gz", "7z", "gz", "gzip", "rar"],
-			"id": 7
+			"id": "decompress"
 		},
 	"mappings": [null, [{
-		"id": 7,
+		"id": "decompress",
 		"title": "decompress/unpack",
 		"app_weight": 1
 	}]]

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -281,7 +281,6 @@ Add a unique id, such as 1,2,3
 """
 
 new_apps = OrderedDict()
-extensions_flat = []
 counter = 0
 for category in mapping:
     apps = mapping[category]
@@ -296,14 +295,10 @@ for category in mapping:
             counter += 1
             new_apps[title] = copy.copy(app)
         # Then for the current app we are looking at,
-        # find the appropriate category and append its extensions list
-        # to the apps list of extensions
-        for extension in type_to_extension_mapping:
-            if extension == category:
-                new_apps[title]["extensions"].extend(
-                    type_to_extension_mapping[extension]
-                )
-                extensions_flat.extend(type_to_extension_mapping[extension])
+        # add appropriate file extensions
+        new_apps[title]["extensions"].extend(
+            type_to_extension_mapping[category]
+        )
 
 # Then create the mapping between file extensions and apps
 # For example, the .gbk and .genkbank extensions map to app with id of 6
@@ -312,14 +307,14 @@ for category in mapping:
 """
     "gbk": [
       {
-        "id": 6,
+        "id": "genbank_genome",
         "title": "genbank_genome",
         "app_weight": 1
       }
     ],
 """
 
-# with 6 being the id of the matched app
+# with "genbank_genome" being the id of the matched app
 # and 1 being a perfect weight score of 100%
 extensions_mapping = defaultdict(list)
 for app_title in new_apps:

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -301,7 +301,7 @@ for category in mapping:
         )
 
 # Then create the mapping between file extensions and apps
-# For example, the .gbk and .genkbank extensions map to app with id of 6
+# For example, the .gbk and .genkbank extensions map to app with id of "genbank_genome"
 # so the mapping would look like
 # mapping['gbk'] =
 """

--- a/staging_service/autodetect/Mappings.py
+++ b/staging_service/autodetect/Mappings.py
@@ -9,7 +9,7 @@ ZIP = "CompressedFileFormatArchive"
 
 # BIOINFORMATICS FORMATS
 FASTA = "FASTA"
-FASTQ = "FASTQ Reads"
+FASTQ = "FASTQ"
 GFF = "GFF"
 GTF = "GTF"
 SRA = "SRA"
@@ -19,9 +19,9 @@ GENBANK = "GENBANK"
 VCF = "VCF"
 FBA = "FBAModel"
 SBML = "SBML"
+MSA = "MSA"
 
 # KBASE SPECIFIC FORMATS
-MSA = "MultipleSequenceAlignment"
 PHENOTYPE = "PHENOTYPE"  # "KBasePhenotypes.PhenotypeSet"
 ESCHER = "ESCHER"
 ANNOTATIONS = "ANNOTATIONS"
@@ -55,11 +55,11 @@ escher_map_id = "escher_map"
 def _flatten(some_list):
     return list(itertools.chain.from_iterable(some_list))
 
-_GZIP_EXT = ["", ".gz", ".gzip"]  # empty string to keep the uncompressed extension
+_COMP_EXT = ["", ".gz", ".gzip"]  # empty string to keep the uncompressed extension
 
 # longer term there's probably a better way to do this but this is quick
 def _add_gzip(extension_list):
-    return _flatten([[ext + gz for gz in _GZIP_EXT] for ext in extension_list])
+    return _flatten([[ext + comp for comp in _COMP_EXT] for ext in extension_list])
 
 type_to_extension_mapping = {
     FASTA: _add_gzip(["fna", "fa", "faa", "fsa", "fasta"]),

--- a/staging_service/autodetect/Mappings.py
+++ b/staging_service/autodetect/Mappings.py
@@ -55,11 +55,11 @@ escher_map_id = "escher_map"
 def _flatten(some_list):
     return list(itertools.chain.from_iterable(some_list))
 
-_COMP_EXT = ["", ".gz", ".gzip"]  # empty string to keep the uncompressed extension
+_COMPRESSION_EXT = ["", ".gz", ".gzip"]  # empty string to keep the uncompressed extension
 
 # longer term there's probably a better way to do this but this is quick
 def _add_gzip(extension_list):
-    return _flatten([[ext + comp for comp in _COMP_EXT] for ext in extension_list])
+    return _flatten([[ext + comp for comp in _COMPRESSION_EXT] for ext in extension_list])
 
 type_to_extension_mapping = {
     FASTA: _add_gzip(["fna", "fa", "faa", "fsa", "fasta"]),


### PR DESCRIPTION
* Change documentation to use the correct string ID rather than a
  numerical ID for apps.
* Simplify and consistent-ify some format names
* Move MSA into regular bioinfo formats
* Change gzip specific variable names into more generic names in case
  we want to add bzip
* Remove the unused extensions_flat variable in the type mapper
* Simplify looking up extensions for apps

These changes made no difference to the type mappings when the mapper
was re-run.