### PR TITLE
Simplify type / app mapping

### DIFF
--- a/deployment/conf/supported_apps_w_extensions.json
+++ b/deployment/conf/supported_apps_w_extensions.json
@@ -278,19 +278,6 @@
       ],
       "_id": 14
     },
-    "Attribute Mapping": {
-      "title": "Attribute Mapping",
-      "app": "kb_uploadmethods/import_attribute_mapping_from_staging",
-      "output_type": [
-        "KBaseExperiments.AttributeMapping"
-      ],
-      "id": "attribute_mapping",
-      "extensions": [
-        "xls",
-        "xlsx"
-      ],
-      "_id": 15
-    },
     "EscherMap": {
       "title": "EscherMap",
       "app": "kb_uploadmethods/import_eschermap_from_staging",
@@ -301,7 +288,7 @@
       "extensions": [
         "json"
       ],
-      "_id": 16
+      "_id": 15
     }
   },
   "types": {
@@ -909,11 +896,6 @@
         "id": "fba_model",
         "title": "FBA Model",
         "app_weight": 1
-      },
-      {
-        "id": "attribute_mapping",
-        "title": "Attribute Mapping",
-        "app_weight": 1
       }
     ],
     "xlsx": [
@@ -930,11 +912,6 @@
       {
         "id": "fba_model",
         "title": "FBA Model",
-        "app_weight": 1
-      },
-      {
-        "id": "attribute_mapping",
-        "title": "Attribute Mapping",
         "app_weight": 1
       }
     ],

--- a/deployment/conf/supported_apps_w_extensions.json
+++ b/deployment/conf/supported_apps_w_extensions.json
@@ -1,26 +1,26 @@
 {
   "apps": {
     "SRA Reads": {
-      "id": "sra_reads",
       "title": "SRA Reads",
       "app": "kb_uploadmethods/import_sra_as_reads_from_staging",
       "output_type": [
         "KBaseFile.SingleEndLibrary",
         "KBaseFile.PairedEndLibrary"
       ],
+      "id": "sra_reads",
       "extensions": [
         "sra"
       ],
       "_id": 0
     },
     "FastQ Reads Interleaved": {
-      "id": "fastq_reads_interleaved",
       "title": "FastQ Reads Interleaved",
       "app": "kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging",
       "output_type": [
         "KBaseFile.SingleEndLibrary",
         "KBaseFile.PairedEndLibrary"
       ],
+      "id": "fastq_reads_interleaved",
       "extensions": [
         "fq",
         "fq.gz",
@@ -32,13 +32,13 @@
       "_id": 1
     },
     "FastQ Reads NonInterleaved": {
-      "id": "fastq_reads_noninterleaved",
       "title": "FastQ Reads NonInterleaved",
       "app": "kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging",
       "output_type": [
         "KBaseFile.SingleEndLibrary",
         "KBaseFile.PairedEndLibrary"
       ],
+      "id": "fastq_reads_noninterleaved",
       "extensions": [
         "fq",
         "fq.gz",
@@ -50,12 +50,12 @@
       "_id": 2
     },
     "Assembly": {
-      "id": "assembly",
       "title": "Assembly",
       "app": "kb_uploadmethods/import_fasta_as_assembly_from_staging",
       "output_type": [
         "KBaseGenomeAnnotations.Assembly"
       ],
+      "id": "assembly",
       "extensions": [
         "fna",
         "fna.gz",
@@ -76,12 +76,12 @@
       "_id": 3
     },
     "GFF/FASTA Genome": {
-      "id": "gff_genome",
       "title": "GFF/FASTA Genome",
       "app": "kb_uploadmethods/import_gff_fasta_as_genome_from_staging",
       "output_type": [
         "KBaseGenomes.Genome"
       ],
+      "id": "gff_genome",
       "extensions": [
         "fna",
         "fna.gz",
@@ -111,12 +111,12 @@
       "_id": 4
     },
     "GFF/FASTA MetaGenome": {
-      "id": "gff_metagenome",
       "title": "GFF/FASTA MetaGenome",
       "app": "kb_uploadmethods/import_gff_fasta_as_metagenome_from_staging",
       "output_type": [
         "KBaseMetagenomes.AnnotatedMetagenomeAssembly"
       ],
+      "id": "gff_metagenome",
       "extensions": [
         "fna",
         "fna.gz",
@@ -146,12 +146,12 @@
       "_id": 5
     },
     "Genbank Genome": {
-      "id": "genbank_genome",
       "title": "Genbank Genome",
       "app": "kb_uploadmethods/import_genbank_as_genome_from_staging",
       "output_type": [
         "KBaseGenomes.Genome"
       ],
+      "id": "genbank_genome",
       "extensions": [
         "gb",
         "gb.gz",
@@ -169,12 +169,12 @@
       "_id": 6
     },
     "Decompress/Unpack": {
-      "id": "decompress",
       "title": "Decompress/Unpack",
       "app": "kb_uploadmethods/unpack_staging_file",
       "output_type": [
         null
       ],
+      "id": "decompress",
       "extensions": [
         "zip",
         "tar",
@@ -202,12 +202,12 @@
       "_id": 8
     },
     "Media": {
-      "id": "media",
       "title": "Media",
       "app": "kb_uploadmethods/import_tsv_excel_as_media_from_staging",
       "output_type": [
         "KBaseBiochem.Media"
       ],
+      "id": "media",
       "extensions": [
         "tsv",
         "xls",
@@ -216,48 +216,48 @@
       "_id": 9
     },
     "Expression Matrix": {
-      "id": "expression_matrix",
       "title": "Expression Matrix",
       "app": "kb_uploadmethods/import_tsv_as_expression_matrix_from_staging",
       "output_type": [
         "KBaseFeatureValues.ExpressionMatrix"
       ],
+      "id": "expression_matrix",
       "extensions": [
         "tsv"
       ],
       "_id": 10
     },
     "Metabolic Annotations": {
-      "id": "metabolic_annotation",
       "title": "Metabolic Annotations",
       "app": "MergeMetabolicAnnotations/import_annotations",
       "output_type": [
         "KBaseGenomes.Genome"
       ],
+      "id": "metabolic_annotation",
       "extensions": [
         "tsv"
       ],
       "_id": 11
     },
     "Bulk Metabolic Annotations": {
-      "id": "metabolic_annotation_bulk",
       "title": "Bulk Metabolic Annotations",
       "app": "MergeMetabolicAnnotations/import_bulk_annotations",
       "output_type": [
         "KBaseGenomes.Genome"
       ],
+      "id": "metabolic_annotation_bulk",
       "extensions": [
         "tsv"
       ],
       "_id": 12
     },
     "FBA Model": {
-      "id": "fba_model",
       "title": "FBA Model",
       "app": "kb_uploadmethods/import_file_as_fba_model_from_staging",
       "output_type": [
         "KBaseFBA.FBAModel"
       ],
+      "id": "fba_model",
       "extensions": [
         "tsv",
         "xls",
@@ -267,24 +267,24 @@
       "_id": 13
     },
     "Phenotype Set": {
-      "id": "phenotype_set",
       "title": "Phenotype Set",
       "app": "kb_uploadmethods/import_tsv_as_phenotype_set_from_staging",
       "output_type": [
         "KBasePhenotypes.PhenotypeSet"
       ],
+      "id": "phenotype_set",
       "extensions": [
         "tsv"
       ],
       "_id": 14
     },
     "Attribute Mapping": {
-      "id": "attribute_mapping",
       "title": "Attribute Mapping",
       "app": "kb_uploadmethods/import_attribute_mapping_from_staging",
       "output_type": [
         "KBaseExperiments.AttributeMapping"
       ],
+      "id": "attribute_mapping",
       "extensions": [
         "xls",
         "xlsx"
@@ -292,12 +292,12 @@
       "_id": 15
     },
     "EscherMap": {
-      "id": "escher_map",
       "title": "EscherMap",
       "app": "kb_uploadmethods/import_eschermap_from_staging",
       "output_type": [
         "KBaseFBA.EscherMap"
       ],
+      "id": "escher_map",
       "extensions": [
         "json"
       ],

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -28,223 +28,114 @@ from collections import defaultdict, OrderedDict
 
 from staging_service.autodetect.Mappings import *
 
-mapping = defaultdict(list)
+# Note that some upload apps are not included - in particular batch apps, which are now
+# redundant, and MSAs because they're out of scope at the current time and don't conform to
+# standards (what does this mean?).
 
-mapping[SRA] = [
-    {
-        "id": sra_reads_id,
+apps = {
+    sra_reads_id: {
         "title": "SRA Reads",
         "app": "kb_uploadmethods/import_sra_as_reads_from_staging",
         "output_type": ["KBaseFile.SingleEndLibrary", "KBaseFile.PairedEndLibrary"],
-    }
-]
-
-mapping[FASTQ] = [
-    {
-        "id": fastq_reads_interleaved_id,
+    },
+    fastq_reads_interleaved_id: {
         "title": "FastQ Reads Interleaved",
         "app": "kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging",
         "output_type": ["KBaseFile.SingleEndLibrary", "KBaseFile.PairedEndLibrary"],
     },
-    {
-        "id": fastq_reads_noninterleaved_id,
+    fastq_reads_noninterleaved_id: {
         "title": "FastQ Reads NonInterleaved",
         "app": "kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging",
         "output_type": ["KBaseFile.SingleEndLibrary", "KBaseFile.PairedEndLibrary"],
     },
-]
-
-mapping[FASTA] = [
-    {
-        "id": assembly_id,
+    assembly_id: {
         "title": "Assembly",
         "app": "kb_uploadmethods/import_fasta_as_assembly_from_staging",
         "output_type": ["KBaseGenomeAnnotations.Assembly"],
     },
-    # Commented out because: Batch App
-    # {
-    #     "title": "Assembly Set",
-    #     "app": "kb_uploadmethods/batch_import_assembly_from_staging",
-    #     "output_type": ["KBaseSets.AssemblySet"],
-    # },
-    {
-        "id": gff_genome_id,
+    gff_genome_id: {
         "title": "GFF/FASTA Genome",
         "app": "kb_uploadmethods/import_gff_fasta_as_genome_from_staging",
         "output_type": ["KBaseGenomes.Genome"],
     },
-    {
-        "id": gff_metagenome_id,
+    gff_metagenome_id: {
         "title": "GFF/FASTA MetaGenome",
         "app": "kb_uploadmethods/import_gff_fasta_as_metagenome_from_staging",
         "output_type": ["KBaseMetagenomes.AnnotatedMetagenomeAssembly"],
     },
-    # Commented out because: Batch App
-    # {
-    #     "title": "GFF/FASTA Genome Set",
-    #     "app": "kb_uploadmethods/batch_import_genome_from_staging",
-    #     "output_type": ["KBaseSearch.GenomeSet"],
-    #     "comment" : "To use: select a directory from the narrative"
-    # },
-    # Commented out because: It doesn't conform to standards and is out of scope right now
-    # {
-    #     "title": "Multiple Sequence Alignment",
-    #     "app": "MSAUtils/import_msa_file",
-    #     "output_type": ["KBaseTrees.MSA"],
-    # },
-]
-# Commented out because: It doesn't conform to standards and is out of scope right now
-# mapping[MSA] = [
-# {
-#     "title": "Multiple Sequence Alignment",
-#     "app": "MSAUtils/import_msa_file",
-#     "output_type": ["KBaseTrees.MSA"],
-# }
-# ]
-
-mapping[GENBANK] = [
-    {
-        "id": genbank_genome_id,
+    genbank_genome_id: {
         "title": "Genbank Genome",
         "app": "kb_uploadmethods/import_genbank_as_genome_from_staging",
         "output_type": ["KBaseGenomes.Genome"],
     },
-    # Commented out because: Batch App
-    # {
-    #     "title": "Genbank Genome Set",
-    #     "app": "kb_uploadmethods/batch_import_genome_from_staging",
-    #     "output_type": ["KBaseSearch.GenomeSet"],
-    #     "hidden" : True
-    # },
-]
-
-mapping[GFF] = [
-    {
-        "id": gff_genome_id,
-        "title": "GFF/FASTA Genome",
-        "app": "kb_uploadmethods/import_gff_fasta_as_genome_from_staging",
-        "output_type": ["KBaseGenomes.Genome"],
-    },
-    {
-        "id": gff_metagenome_id,
-        "title": "GFF/FASTA MetaGenome",
-        "app": "kb_uploadmethods/import_gff_fasta_as_metagenome_from_staging",
-        "output_type": ["KBaseMetagenomes.AnnotatedMetagenomeAssembly"],
-    },
-    # Commented out because: Batch App
-    # {
-    #     "title": "GFF/FASTA Genome Set",
-    #     "app": "kb_uploadmethods/batch_import_genome_from_staging",
-    #     "output_type": ["KBaseSearch.GenomeSet"],
-    #     "hidden": True
-    # },
-]
-
-mapping[ZIP] = [
-    {
-        "id": decompress_id,
+    decompress_id: {
         "title": "Decompress/Unpack",
         "app": "kb_uploadmethods/unpack_staging_file",
         "output_type": [None],
-    }
-]
-mapping[CSV] = [
-    {
+    },
+    sample_set_id: {
         "id": sample_set_id,
         "title": "Samples",
         "app": "sample_uploader/import_samples",
         "output_type": ["KBaseSets.SampleSet"],
-    }
-]
-
-mapping[TSV] = [
-    {
-        "id": media_id,
+    },
+    media_id: {
         "title": "Media",
         "app": "kb_uploadmethods/import_tsv_excel_as_media_from_staging",
         "output_type": ["KBaseBiochem.Media"],
     },
-    # Commented out because: Not in scope and requires an object
-    # {
-    #     "title": "Attribute Mapping",
-    #     "app": "kb_uploadmethods/import_attribute_mapping_from_staging",
-    #     "output_type": ["KBaseExperiments.AttributeMapping"],
-    # },
-    {
-        "id": expression_matrix_id,
+    expression_matrix_id: {
         "title": "Expression Matrix",
         "app": "kb_uploadmethods/import_tsv_as_expression_matrix_from_staging",
         "output_type": ["KBaseFeatureValues.ExpressionMatrix"],
     },
-    {
-        "id": metabolic_annotations_id,
+    metabolic_annotations_id: {
         "title": "Metabolic Annotations",
         "app": "MergeMetabolicAnnotations/import_annotations",
         "output_type": ["KBaseGenomes.Genome"],
     },
-    {
-        "id": metabolic_annotations_bulk_id,
+    metabolic_annotations_bulk_id: {
         "title": "Bulk Metabolic Annotations",
         "app": "MergeMetabolicAnnotations/import_bulk_annotations",
         "output_type": ["KBaseGenomes.Genome"],
     },
-    {
-        "id": fba_model_id,
+    fba_model_id: {
         "title": "FBA Model",
         "app": "kb_uploadmethods/import_file_as_fba_model_from_staging",
         "output_type": ["KBaseFBA.FBAModel"],
     },
-    {
-        "id": phenotype_set_id,
+    phenotype_set_id: {
         "title": "Phenotype Set",
         "app": "kb_uploadmethods/import_tsv_as_phenotype_set_from_staging",
         "output_type": ["KBasePhenotypes.PhenotypeSet"],
     },
-]
-
-mapping[EXCEL] = [
-    {
-        "id": sample_set_id,
-        "title": "Samples",
-        "app": "sample_uploader/import_samples",
-        "output_type": ["KBaseSets.SampleSet"],
-    },
-    {
-        "id": media_id,
-        "title": "Media",
-        "app": "kb_uploadmethods/import_tsv_excel_as_media_from_staging",
-        "output_type": ["KBaseBiochem.Media"],
-    },
-    {
-        "id": attribute_mapping_id,
+    attribute_mapping_id: {
         "title": "Attribute Mapping",
         "app": "kb_uploadmethods/import_attribute_mapping_from_staging",
         "output_type": ["KBaseExperiments.AttributeMapping"],
     },
-    {
-        "id": fba_model_id,
-        "title": "FBA Model",
-        "app": "kb_uploadmethods/import_file_as_fba_model_from_staging",
-        "output_type": ["KBaseFBA.FBAModel"],
-    },
-]
-mapping[JSON] = [
-    {
-        "id": escher_map_id,
+    escher_map_id: {
         "title": "EscherMap",
         "app": "kb_uploadmethods/import_eschermap_from_staging",
         "output_type": ["KBaseFBA.EscherMap"],
-    }
-]
+    },
 
-mapping[SBML] = [
-    {
-        "id": fba_model_id,
-        "title": "FBA Model",
-        "app": "kb_uploadmethods/import_file_as_fba_model_from_staging",
-        "output_type": ["KBaseFBA.FBAModel"],
-    }
-]
+}
+
+mapping = {}
+
+mapping[SRA] = [sra_reads_id]
+mapping[FASTQ] = [fastq_reads_interleaved_id, fastq_reads_noninterleaved_id]
+mapping[FASTA] = [assembly_id, gff_genome_id, gff_metagenome_id]
+mapping[GENBANK] = [genbank_genome_id]
+mapping[GFF] = [gff_genome_id, gff_metagenome_id]
+mapping[ZIP] = [decompress_id]
+mapping[CSV] = [sample_set_id]
+mapping[TSV] = [media_id, expression_matrix_id, metabolic_annotations_id,
+                metabolic_annotations_bulk_id, fba_model_id, phenotype_set_id]
+mapping[EXCEL] = [sample_set_id, media_id, attribute_mapping_id, fba_model_id]
+mapping[JSON] = [escher_map_id]
+mapping[SBML] = [fba_model_id]
 
 """
 This turns an app from this
@@ -268,7 +159,7 @@ to
         "gbk",
         "genbank"
       ],
-      "id": 6
+      "id": "genbank"
     },
 
 """
@@ -283,22 +174,22 @@ Add a unique id, such as 1,2,3
 new_apps = OrderedDict()
 counter = 0
 for category in mapping:
-    apps = mapping[category]
-    for app in apps:
+    for app_id in mapping[category]:
+        app = apps[app_id]
         # print("looking at", app)
         title = app["title"]
 
         if title not in new_apps:
+            new_app = copy.copy(app)
             # Create a new entry for extensions and id in the app
-            app["extensions"] = []
-            app["_id"] = counter
+            new_app["id"] = app_id
+            new_app["extensions"] = []
+            new_app["_id"] = counter
             counter += 1
-            new_apps[title] = copy.copy(app)
+            new_apps[title] = new_app
         # Then for the current app we are looking at,
         # add appropriate file extensions
-        new_apps[title]["extensions"].extend(
-            type_to_extension_mapping[category]
-        )
+        new_apps[title]["extensions"].extend(type_to_extension_mapping[category])
 
 # Then create the mapping between file extensions and apps
 # For example, the .gbk and .genkbank extensions map to app with id of "genbank_genome"

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -29,8 +29,7 @@ from collections import defaultdict, OrderedDict
 from staging_service.autodetect.Mappings import *
 
 # Note that some upload apps are not included - in particular batch apps, which are now
-# redundant, and MSAs because they're out of scope at the current time and don't conform to
-# standards (what does this mean?).
+# redundant, and MSAs and attribute mappings because they're out of scope at the current time.
 
 apps = {
     sra_reads_id: {
@@ -109,11 +108,6 @@ apps = {
         "app": "kb_uploadmethods/import_tsv_as_phenotype_set_from_staging",
         "output_type": ["KBasePhenotypes.PhenotypeSet"],
     },
-    attribute_mapping_id: {
-        "title": "Attribute Mapping",
-        "app": "kb_uploadmethods/import_attribute_mapping_from_staging",
-        "output_type": ["KBaseExperiments.AttributeMapping"],
-    },
     escher_map_id: {
         "title": "EscherMap",
         "app": "kb_uploadmethods/import_eschermap_from_staging",
@@ -122,20 +116,20 @@ apps = {
 
 }
 
-mapping = {}
+file_format_to_app_mapping = {}
 
-mapping[SRA] = [sra_reads_id]
-mapping[FASTQ] = [fastq_reads_interleaved_id, fastq_reads_noninterleaved_id]
-mapping[FASTA] = [assembly_id, gff_genome_id, gff_metagenome_id]
-mapping[GENBANK] = [genbank_genome_id]
-mapping[GFF] = [gff_genome_id, gff_metagenome_id]
-mapping[ZIP] = [decompress_id]
-mapping[CSV] = [sample_set_id]
-mapping[TSV] = [media_id, expression_matrix_id, metabolic_annotations_id,
+file_format_to_app_mapping[SRA] = [sra_reads_id]
+file_format_to_app_mapping[FASTQ] = [fastq_reads_interleaved_id, fastq_reads_noninterleaved_id]
+file_format_to_app_mapping[FASTA] = [assembly_id, gff_genome_id, gff_metagenome_id]
+file_format_to_app_mapping[GENBANK] = [genbank_genome_id]
+file_format_to_app_mapping[GFF] = [gff_genome_id, gff_metagenome_id]
+file_format_to_app_mapping[ZIP] = [decompress_id]
+file_format_to_app_mapping[CSV] = [sample_set_id]
+file_format_to_app_mapping[TSV] = [media_id, expression_matrix_id, metabolic_annotations_id,
                 metabolic_annotations_bulk_id, fba_model_id, phenotype_set_id]
-mapping[EXCEL] = [sample_set_id, media_id, attribute_mapping_id, fba_model_id]
-mapping[JSON] = [escher_map_id]
-mapping[SBML] = [fba_model_id]
+file_format_to_app_mapping[EXCEL] = [sample_set_id, media_id, fba_model_id]
+file_format_to_app_mapping[JSON] = [escher_map_id]
+file_format_to_app_mapping[SBML] = [fba_model_id]
 
 """
 This turns an app from this
@@ -173,8 +167,8 @@ Add a unique id, such as 1,2,3
 
 new_apps = OrderedDict()
 counter = 0
-for category in mapping:
-    for app_id in mapping[category]:
+for category in file_format_to_app_mapping:
+    for app_id in file_format_to_app_mapping[category]:
         app = apps[app_id]
         # print("looking at", app)
         title = app["title"]
@@ -189,7 +183,7 @@ for category in mapping:
             new_apps[title] = new_app
         # Then for the current app we are looking at,
         # add appropriate file extensions
-        new_apps[title]["extensions"].extend(type_to_extension_mapping[category])
+        new_apps[title]["extensions"].extend(file_format_to_extension_mapping[category])
 
 # Then create the mapping between file extensions and apps
 # For example, the .gbk and .genkbank extensions map to app with id of "genbank_genome"

--- a/staging_service/autodetect/Mappings.py
+++ b/staging_service/autodetect/Mappings.py
@@ -61,7 +61,7 @@ _COMPRESSION_EXT = ["", ".gz", ".gzip"]  # empty string to keep the uncompressed
 def _add_gzip(extension_list):
     return _flatten([[ext + comp for comp in _COMPRESSION_EXT] for ext in extension_list])
 
-type_to_extension_mapping = {
+file_format_to_extension_mapping = {
     FASTA: _add_gzip(["fna", "fa", "faa", "fsa", "fasta"]),
     FASTQ: _add_gzip(["fq", "fastq"]),
     GFF: _add_gzip(["gff", "gff2", "gff3"]),
@@ -93,10 +93,10 @@ type_to_extension_mapping = {
     SBML: ["smbl"],
 }
 
-extension_to_type_mapping = {}
-for type_, extensions in type_to_extension_mapping.items():
+extension_to_file_format_mapping = {}
+for type_, extensions in file_format_to_extension_mapping.items():
     for ext in extensions:
-        if ext in extension_to_type_mapping:
-            type2 = extension_to_type_mapping[ext]
+        if ext in extension_to_file_format_mapping:
+            type2 = extension_to_file_format_mapping[ext]
             raise ValueError(f"Duplicate entry for extension {ext} in {type_} and {type2}")
-        extension_to_type_mapping[ext] = type_
+        extension_to_file_format_mapping[ext] = type_

--- a/staging_service/autodetect/Mappings.py
+++ b/staging_service/autodetect/Mappings.py
@@ -91,10 +91,12 @@ type_to_extension_mapping = {
     EXCEL: ["xls", "xlsx"],
     ZIP: ["zip", "tar", "tgz", "tar.gz", "7z", "gz", "gzip", "rar"],
     SBML: ["smbl"],
-    # Custom File Types?
-    MEDIA: ["tsv", "xls", "xlsx"],
-    PHENOTYPE: ["tsv"],
-    ESCHER: ["json"],
-    ANNOTATIONS: ["tsv"],
-    FBA: ["tsv", "xls", "xlsx", "smbl"],
 }
+
+extension_to_type_mapping = {}
+for type_, extensions in type_to_extension_mapping.items():
+    for ext in extensions:
+        if ext in extension_to_type_mapping:
+            type2 = extension_to_type_mapping[ext]
+            raise ValueError(f"Duplicate entry for extension {ext} in {type_} and {type2}")
+        extension_to_type_mapping[ext] = type_

--- a/tests/test_autodetect.py
+++ b/tests/test_autodetect.py
@@ -1,5 +1,5 @@
 import pytest
-from staging_service.autodetect.GenerateMappings import type_to_extension_mapping
+from staging_service.autodetect.GenerateMappings import file_format_to_extension_mapping
 from staging_service.AutoDetectUtils import AutoDetectUtils
 from staging_service.app import inject_config_dependencies
 from tests.test_utils import bootstrap_config
@@ -44,8 +44,8 @@ def test_reasonable_filenames():
     """
 
     good_filenames = []
-    for heading in type_to_extension_mapping.keys():
-        extensions = type_to_extension_mapping[heading]
+    for heading in file_format_to_extension_mapping.keys():
+        extensions = file_format_to_extension_mapping[heading]
         for extension in extensions:
             good_filenames.append((f"{heading}.{extension}", heading.count(".")))
 


### PR DESCRIPTION
Currently you can assign multiple apps to a file type category *and* multiple
file extensions to a file type category. That means that given a file
extension and an app it's not always possible to determine the file category.
Further, these 2 degrees of freedom aren't necessary to correctly assign apps
to file extensions - allowing multiple apps per category allows that.

So
* ensure that file extensions only appear once in the file category map
  * it turns out that deleting the custom categories fixed this issue
* Define the apps in a separate mapping from the category -> app mapping,
  since currently the same app is defined multiple times, once per each
  category.

This changes nothing in the resulting app mapping JSON other than the
ordering of some keys.