### PR TITLE
Add file type / category to extension mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ Response:
 		"id": "decompress",
 		"title": "decompress/unpack",
 		"app_weight": 1,
-        "file_type": "CompressedFileFormatArchive",
+		"file_type": "CompressedFileFormatArchive",
 	}]]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -777,7 +777,8 @@ Response:
 	"mappings": [null, [{
 		"id": "decompress",
 		"title": "decompress/unpack",
-		"app_weight": 1
+		"app_weight": 1,
+        "file_type": "CompressedFileFormatArchive",
 	}]]
 }
 ```
@@ -789,3 +790,50 @@ Response:
 must provide file_list field 
 ```
 
+# Autodetect App and File Type IDs
+
+## App type IDs
+
+These are the currently supported upload app type IDs:
+
+```
+fastq_reads_interleaved
+fastq_reads_noninterleaved
+sra_reads
+genbank_genome
+gff_genome
+gff_metagenome
+expression_matrix
+media
+fba_model
+assembly
+phenotype_set
+sample_set
+metabolic_annotation
+metabolic_annotation_bulk
+attribute_mapping
+escher_map
+decompress
+```
+
+Note that decompress is only returned when no other file type can be detected from the file
+extension.
+
+## File type IDs
+
+These are the currently supported file type IDs. These are primarily useful for apps that take
+two different file types, like GFF/FASTA genomes.
+
+```
+FASTA
+FASTQ
+SRA
+GFF
+GENBANK
+SBML
+JSON
+TSV
+CSV
+EXCEL
+CompressedFileFormatArchive
+```

--- a/README.md
+++ b/README.md
@@ -811,7 +811,6 @@ phenotype_set
 sample_set
 metabolic_annotation
 metabolic_annotation_bulk
-attribute_mapping
 escher_map
 decompress
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### Version 1.1.10
+- added a `file_type` field to the file extension mappings.
+
 ### Version 1.1.9
 - Added support for Genbank *.gb and *.gbff extensions
 - Added support for gzipped Reads, Assemblies, Genbank Files, and GFF files.

--- a/deployment/conf/supported_apps_w_extensions.json
+++ b/deployment/conf/supported_apps_w_extensions.json
@@ -296,669 +296,1002 @@
       {
         "id": "sra_reads",
         "title": "SRA Reads",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "SRA"
+        ]
       }
     ],
     "fq": [
       {
         "id": "fastq_reads_interleaved",
         "title": "FastQ Reads Interleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       },
       {
         "id": "fastq_reads_noninterleaved",
         "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       }
     ],
     "fq.gz": [
       {
         "id": "fastq_reads_interleaved",
         "title": "FastQ Reads Interleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       },
       {
         "id": "fastq_reads_noninterleaved",
         "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       }
     ],
     "fq.gzip": [
       {
         "id": "fastq_reads_interleaved",
         "title": "FastQ Reads Interleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       },
       {
         "id": "fastq_reads_noninterleaved",
         "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       }
     ],
     "fastq": [
       {
         "id": "fastq_reads_interleaved",
         "title": "FastQ Reads Interleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       },
       {
         "id": "fastq_reads_noninterleaved",
         "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       }
     ],
     "fastq.gz": [
       {
         "id": "fastq_reads_interleaved",
         "title": "FastQ Reads Interleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       },
       {
         "id": "fastq_reads_noninterleaved",
         "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       }
     ],
     "fastq.gzip": [
       {
         "id": "fastq_reads_interleaved",
         "title": "FastQ Reads Interleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       },
       {
         "id": "fastq_reads_noninterleaved",
         "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTQ"
+        ]
       }
     ],
     "fna": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fna.gz": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fna.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fa": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fa.gz": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fa.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "faa": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "faa.gz": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "faa.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fsa": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fsa.gz": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fsa.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fasta": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fasta.gz": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "fasta.gzip": [
       {
         "id": "assembly",
         "title": "Assembly",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "FASTA"
+        ]
       }
     ],
     "gff": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff.gz": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff.gzip": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff2": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff2.gz": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff2.gzip": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff3": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff3.gz": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gff3.gzip": [
       {
         "id": "gff_genome",
         "title": "GFF/FASTA Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       },
       {
         "id": "gff_metagenome",
         "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GFF"
+        ]
       }
     ],
     "gb": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gb.gz": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gb.gzip": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gbff": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gbff.gz": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gbff.gzip": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gbk": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gbk.gz": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "gbk.gzip": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "genbank": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "genbank.gz": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "genbank.gzip": [
       {
         "id": "genbank_genome",
         "title": "Genbank Genome",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "GENBANK"
+        ]
       }
     ],
     "zip": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "tar": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "tgz": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "tar.gz": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "7z": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "gz": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "gzip": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "rar": [
       {
         "id": "decompress",
         "title": "Decompress/Unpack",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CompressedFileFormatArchive"
+        ]
       }
     ],
     "csv": [
       {
         "id": "sample_set",
         "title": "Samples",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "CSV"
+        ]
       }
     ],
     "xls": [
       {
         "id": "sample_set",
         "title": "Samples",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "EXCEL"
+        ]
       },
       {
         "id": "media",
         "title": "Media",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "EXCEL"
+        ]
       },
       {
         "id": "fba_model",
         "title": "FBA Model",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "EXCEL"
+        ]
       }
     ],
     "xlsx": [
       {
         "id": "sample_set",
         "title": "Samples",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "EXCEL"
+        ]
       },
       {
         "id": "media",
         "title": "Media",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "EXCEL"
+        ]
       },
       {
         "id": "fba_model",
         "title": "FBA Model",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "EXCEL"
+        ]
       }
     ],
     "tsv": [
       {
         "id": "media",
         "title": "Media",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "TSV"
+        ]
       },
       {
         "id": "expression_matrix",
         "title": "Expression Matrix",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "TSV"
+        ]
       },
       {
         "id": "metabolic_annotation",
         "title": "Metabolic Annotations",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "TSV"
+        ]
       },
       {
         "id": "metabolic_annotation_bulk",
         "title": "Bulk Metabolic Annotations",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "TSV"
+        ]
       },
       {
         "id": "fba_model",
         "title": "FBA Model",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "TSV"
+        ]
       },
       {
         "id": "phenotype_set",
         "title": "Phenotype Set",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "TSV"
+        ]
       }
     ],
     "smbl": [
       {
         "id": "fba_model",
         "title": "FBA Model",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "SBML"
+        ]
       }
     ],
     "json": [
       {
         "id": "escher_map",
         "title": "EscherMap",
-        "app_weight": 1
+        "app_weight": 1,
+        "file_type": [
+          "JSON"
+        ]
       }
     ]
   }

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -15,7 +15,7 @@ from .metadata import some_metadata, dir_info, add_upa, similar
 from .utils import Path, run_command, AclManager
 
 routes = web.RouteTableDef()
-VERSION = "1.1.9"
+VERSION = "1.1.10"
 
 
 @routes.get("/importer_mappings/{query:.*}")

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -159,7 +159,7 @@ to
 """
 
 """
-For each category in mapping (current SMBl/JSOn/FASTQ/FASTA/ etc), get an "App"
+For each category in mapping (current SMBl/JSON/FASTQ/FASTA/ etc), get an "App"
 Create the app in a list of  using the title as the primary hashing key
 Add a list of extensions, such as .fa, fasta
 Add a unique id, such as 1,2,3
@@ -211,7 +211,16 @@ for app_title in new_apps:
     perfect_match_weight = 1
     for extension in extensions:
         extensions_mapping[extension].append(
-            {"id": app_id, "title": app_title, "app_weight": perfect_match_weight}
+            {
+                "id": app_id,
+                "title": app_title,
+                "app_weight": perfect_match_weight,
+                # make a list to allow for expansion in the future - for example it could
+                # include whether reads are forward or reverse if we get smarter about name
+                # detection. For backwards compatibilily, we'd leave the current FASTQ type and
+                # add a FASTQ-FWD or FWD type or something.
+                "file_type": [extension_to_file_format_mapping[extension]],
+            }
         )
 
 if __name__ == "__main__":

--- a/tests/test_autodetect.py
+++ b/tests/test_autodetect.py
@@ -74,19 +74,47 @@ def test_specific_filenames():
         ("filename", None),
         ("file.name", None),
         ("fil.en.ame", None),
-        ("file.gZ", [{'app_weight': 1, 'id': 'decompress', 'title': 'Decompress/Unpack'}]
+        ("file.gZ", [{
+            'app_weight': 1,
+            'id': 'decompress',
+            'title': 'Decompress/Unpack',
+            'file_type': ['CompressedFileFormatArchive'],
+            }]
          ),
-        ("file.name.gZ", [{'app_weight': 1, 'id': 'decompress', 'title': 'Decompress/Unpack'}]
+        ("file.name.gZ", [{
+            'app_weight': 1,
+            'id': 'decompress',
+            'title': 'Decompress/Unpack',
+            'file_type': ['CompressedFileFormatArchive'],
+            }]
          ),
         ("oscar_the_grouch_does_meth.FaStA.gz", [
-            {'app_weight': 1, 'id': 'assembly', 'title': 'Assembly'},
-            {'app_weight': 1, 'id': 'gff_genome', 'title': 'GFF/FASTA Genome'},
-            {'app_weight': 1, 'id': 'gff_metagenome', 'title': 'GFF/FASTA MetaGenome'}
+            {'app_weight': 1,
+             'id': 'assembly',
+             'title': 'Assembly',
+             'file_type': ['FASTA']
+             },
+            {'app_weight': 1,
+             'id': 'gff_genome',
+             'title': 'GFF/FASTA Genome',
+             'file_type': ['FASTA']
+             },
+            {'app_weight': 1,
+             'id': 'gff_metagenome',
+             'title': 'GFF/FASTA MetaGenome',
+             'file_type': ['FASTA']
+             }
             ]
          ),
         ("look.at.all.these.frigging.dots.gff2.gzip", [
-            {'app_weight': 1, 'id': 'gff_genome', 'title': 'GFF/FASTA Genome'},
-            {'app_weight': 1, 'id': 'gff_metagenome', 'title': 'GFF/FASTA MetaGenome'}
+            {'app_weight': 1,
+             'id': 'gff_genome',
+             'title': 'GFF/FASTA Genome',
+             'file_type': ['GFF']},
+            {'app_weight': 1,
+             'id': 'gff_metagenome',
+             'title': 'GFF/FASTA MetaGenome',
+             'file_type': ['GFF']}
             ]
          )
     ]


### PR DESCRIPTION
This is primarily of benefit when an app takes 2 different file types as input.
Currently there's no way for the client to tell which file is which.