### PR TITLE
Hide dotfiles by default, disallow dotfile uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ second element in request body should be multipart file data
 
 uploads: {multipart file}
 
+Files starting with whitespace or a '.' are not allowed
+
 ## Success Response
 
 **Code** : `200 OK`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 ### Version 1.1.10
 - added a `file_type` field to the file extension mappings.
+- reverted change to expose dotfiles in the api by default
+- attempting to upload a dotfile will now cause an error
 
 ### Version 1.1.9
 - Added support for Genbank *.gb and *.gbff extensions

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -274,8 +274,14 @@ async def upload_files_chunked(request: web.Request):
 
     filename: str = user_file.filename
     if filename.lstrip() != filename:
-        raise web.HTTPForbidden(
+        raise web.HTTPForbidden(  # forbidden isn't really the right code, should be 400
             text="cannot upload file with name beginning with space"
+        )
+    # may want to make this configurable if we ever decide to add a hidden files toggle to
+    # the staging area UI
+    if filename.startswith("."):
+        raise web.HTTPForbidden(  # for consistency we use 403 again
+            text="cannot upload file with name beginning with '.'"
         )
 
     size = 0

--- a/staging_service/metadata.py
+++ b/staging_service/metadata.py
@@ -122,7 +122,9 @@ async def dir_info(
     response = []
     for entry in os.scandir(path.full_path):
         specific_path = Path.from_full_path(entry.path)
-        if not show_hidden and ".globus_id" in entry.name:
+        # maybe should never show the special .globus_id file ever?
+        # or moving it somewhere outside the user directory would be better
+        if not show_hidden and entry.name.startswith('.'):
             continue
         if entry.is_dir():
             if query == "" or specific_path.user_path.find(query) != -1:


### PR DESCRIPTION
Note that there is a showHidden parameter for listing files that will expose all dotfiles (including .globus_id, which may not be desirable)