### PR TITLE
Move file type to file info

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,9 +731,11 @@ Error Connecting to auth service ...
 
 This endpoint returns:
 1) a mapping between a list of files and predicted importer apps, and
-2) the input file names split between the file prefix and the the file suffix, if any, that was
-   used to determine the file -> importer mapping. If a file has a suffix that does not match
-   any mapping (e.g. `.sys`), the suffix will be `null` and the prefix the entire file name.
+2) a file information list that includes the input file names split between the file prefix and
+   the file suffix, if any, that was used to determine the file -> importer mapping, and a list
+   of file types based on the file suffix. If a file has a suffix that does not match
+   any mapping (e.g. `.sys`), the suffix will be `null`, the prefix the entire file name, and
+   the file type list empty.
 
 For example,
  * if we pass in nothing we get a response with no mappings
@@ -773,25 +775,22 @@ Response:
             "id": "decompress",
             "title": "decompress/unpack",
             "app_weight": 1,
-            "file_type": "CompressedFileFormatArchive",
         }],
         [{
-            'app_weight': 1,
-            'id': 'gff_genome',
-            'title': 'GFF/FASTA Genome',
-            'file_type': ['GFF']
+            "app_weight": 1,
+            "id": "gff_genome",
+            "title": "GFF/FASTA Genome",
           },
          {
-            'app_weight': 1,
-            'id': 'gff_metagenome',
-            'title': 'GFF/FASTA MetaGenome',
-            'file_type': ['GFF']
+            "app_weight": 1,
+            "id": "gff_metagenome",
+            "title": "GFF/FASTA MetaGenome",
         }]
     ],
     "fileinfo": [
-        {"prefix": "file1.txt", "suffix": null},
-        {"prefix": "file2", "suffix": "zip"},
-        {"prefix": "file3", "suffix": "gff3.gz"}
+        {"prefix": "file1.txt", "suffix": null, "file_ext_type": []},
+        {"prefix": "file2", "suffix": "zip", "file_ext_type": ["CompressedFileFormatArchive"]},
+        {"prefix": "file3", "suffix": "gff3.gz", "file_ext_type": ["GFF"]}
     ]
 }
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,7 @@
 ### Version 1.2.0
 - BACKWARDS INCOMPATIBILITY: remove the unused `apps` key from the importer mappings endpoint.
-- added a `file_type` field to the file extension mappings.
 - added a `fileinfo` field to the return of the importer mappings endpoint that includes the
-  file prefix and suffix.
+  file prefix, suffix, and file type(s), if any.
 - reverted change to expose dotfiles in the api by default
 - attempting to upload a dotfile will now cause an error
 

--- a/deployment/conf/supported_apps_w_extensions.json
+++ b/deployment/conf/supported_apps_w_extensions.json
@@ -145,1007 +145,959 @@
     ]
   },
   "types": {
-    "sra": [
-      {
-        "id": "sra_reads",
-        "title": "SRA Reads",
-        "app_weight": 1,
-        "file_type": [
-          "SRA"
-        ]
-      }
-    ],
-    "fq": [
-      {
-        "id": "fastq_reads_interleaved",
-        "title": "FastQ Reads Interleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      },
-      {
-        "id": "fastq_reads_noninterleaved",
-        "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      }
-    ],
-    "fq.gz": [
-      {
-        "id": "fastq_reads_interleaved",
-        "title": "FastQ Reads Interleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      },
-      {
-        "id": "fastq_reads_noninterleaved",
-        "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      }
-    ],
-    "fq.gzip": [
-      {
-        "id": "fastq_reads_interleaved",
-        "title": "FastQ Reads Interleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      },
-      {
-        "id": "fastq_reads_noninterleaved",
-        "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      }
-    ],
-    "fastq": [
-      {
-        "id": "fastq_reads_interleaved",
-        "title": "FastQ Reads Interleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      },
-      {
-        "id": "fastq_reads_noninterleaved",
-        "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      }
-    ],
-    "fastq.gz": [
-      {
-        "id": "fastq_reads_interleaved",
-        "title": "FastQ Reads Interleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      },
-      {
-        "id": "fastq_reads_noninterleaved",
-        "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      }
-    ],
-    "fastq.gzip": [
-      {
-        "id": "fastq_reads_interleaved",
-        "title": "FastQ Reads Interleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      },
-      {
-        "id": "fastq_reads_noninterleaved",
-        "title": "FastQ Reads NonInterleaved",
-        "app_weight": 1,
-        "file_type": [
-          "FASTQ"
-        ]
-      }
-    ],
-    "fna": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fna.gz": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fna.gzip": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fa": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fa.gz": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fa.gzip": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "faa": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "faa.gz": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "faa.gzip": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fsa": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fsa.gz": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fsa.gzip": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fasta": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fasta.gz": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "fasta.gzip": [
-      {
-        "id": "assembly",
-        "title": "Assembly",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "FASTA"
-        ]
-      }
-    ],
-    "gff": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff.gz": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff.gzip": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff2": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff2.gz": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff2.gzip": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff3": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff3.gz": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gff3.gzip": [
-      {
-        "id": "gff_genome",
-        "title": "GFF/FASTA Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      },
-      {
-        "id": "gff_metagenome",
-        "title": "GFF/FASTA MetaGenome",
-        "app_weight": 1,
-        "file_type": [
-          "GFF"
-        ]
-      }
-    ],
-    "gb": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gb.gz": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gb.gzip": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gbff": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gbff.gz": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gbff.gzip": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gbk": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gbk.gz": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "gbk.gzip": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "genbank": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "genbank.gz": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "genbank.gzip": [
-      {
-        "id": "genbank_genome",
-        "title": "Genbank Genome",
-        "app_weight": 1,
-        "file_type": [
-          "GENBANK"
-        ]
-      }
-    ],
-    "zip": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "tar": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "tgz": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "tar.gz": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "7z": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "gz": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "gzip": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "rar": [
-      {
-        "id": "decompress",
-        "title": "Decompress/Unpack",
-        "app_weight": 1,
-        "file_type": [
-          "CompressedFileFormatArchive"
-        ]
-      }
-    ],
-    "csv": [
-      {
-        "id": "sample_set",
-        "title": "Samples",
-        "app_weight": 1,
-        "file_type": [
-          "CSV"
-        ]
-      }
-    ],
-    "xls": [
-      {
-        "id": "sample_set",
-        "title": "Samples",
-        "app_weight": 1,
-        "file_type": [
-          "EXCEL"
-        ]
-      },
-      {
-        "id": "media",
-        "title": "Media",
-        "app_weight": 1,
-        "file_type": [
-          "EXCEL"
-        ]
-      },
-      {
-        "id": "fba_model",
-        "title": "FBA Model",
-        "app_weight": 1,
-        "file_type": [
-          "EXCEL"
-        ]
-      }
-    ],
-    "xlsx": [
-      {
-        "id": "sample_set",
-        "title": "Samples",
-        "app_weight": 1,
-        "file_type": [
-          "EXCEL"
-        ]
-      },
-      {
-        "id": "media",
-        "title": "Media",
-        "app_weight": 1,
-        "file_type": [
-          "EXCEL"
-        ]
-      },
-      {
-        "id": "fba_model",
-        "title": "FBA Model",
-        "app_weight": 1,
-        "file_type": [
-          "EXCEL"
-        ]
-      }
-    ],
-    "tsv": [
-      {
-        "id": "media",
-        "title": "Media",
-        "app_weight": 1,
-        "file_type": [
-          "TSV"
-        ]
-      },
-      {
-        "id": "expression_matrix",
-        "title": "Expression Matrix",
-        "app_weight": 1,
-        "file_type": [
-          "TSV"
-        ]
-      },
-      {
-        "id": "metabolic_annotation",
-        "title": "Metabolic Annotations",
-        "app_weight": 1,
-        "file_type": [
-          "TSV"
-        ]
-      },
-      {
-        "id": "metabolic_annotation_bulk",
-        "title": "Bulk Metabolic Annotations",
-        "app_weight": 1,
-        "file_type": [
-          "TSV"
-        ]
-      },
-      {
-        "id": "fba_model",
-        "title": "FBA Model",
-        "app_weight": 1,
-        "file_type": [
-          "TSV"
-        ]
-      },
-      {
-        "id": "phenotype_set",
-        "title": "Phenotype Set",
-        "app_weight": 1,
-        "file_type": [
-          "TSV"
-        ]
-      }
-    ],
-    "smbl": [
-      {
-        "id": "fba_model",
-        "title": "FBA Model",
-        "app_weight": 1,
-        "file_type": [
-          "SBML"
-        ]
-      }
-    ],
-    "json": [
-      {
-        "id": "escher_map",
-        "title": "EscherMap",
-        "app_weight": 1,
-        "file_type": [
-          "JSON"
-        ]
-      }
-    ]
+    "sra": {
+      "file_ext_type": [
+        "SRA"
+      ],
+      "mappings": [
+        {
+          "id": "sra_reads",
+          "title": "SRA Reads",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fq": {
+      "file_ext_type": [
+        "FASTQ"
+      ],
+      "mappings": [
+        {
+          "id": "fastq_reads_interleaved",
+          "title": "FastQ Reads Interleaved",
+          "app_weight": 1
+        },
+        {
+          "id": "fastq_reads_noninterleaved",
+          "title": "FastQ Reads NonInterleaved",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fq.gz": {
+      "file_ext_type": [
+        "FASTQ"
+      ],
+      "mappings": [
+        {
+          "id": "fastq_reads_interleaved",
+          "title": "FastQ Reads Interleaved",
+          "app_weight": 1
+        },
+        {
+          "id": "fastq_reads_noninterleaved",
+          "title": "FastQ Reads NonInterleaved",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fq.gzip": {
+      "file_ext_type": [
+        "FASTQ"
+      ],
+      "mappings": [
+        {
+          "id": "fastq_reads_interleaved",
+          "title": "FastQ Reads Interleaved",
+          "app_weight": 1
+        },
+        {
+          "id": "fastq_reads_noninterleaved",
+          "title": "FastQ Reads NonInterleaved",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fastq": {
+      "file_ext_type": [
+        "FASTQ"
+      ],
+      "mappings": [
+        {
+          "id": "fastq_reads_interleaved",
+          "title": "FastQ Reads Interleaved",
+          "app_weight": 1
+        },
+        {
+          "id": "fastq_reads_noninterleaved",
+          "title": "FastQ Reads NonInterleaved",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fastq.gz": {
+      "file_ext_type": [
+        "FASTQ"
+      ],
+      "mappings": [
+        {
+          "id": "fastq_reads_interleaved",
+          "title": "FastQ Reads Interleaved",
+          "app_weight": 1
+        },
+        {
+          "id": "fastq_reads_noninterleaved",
+          "title": "FastQ Reads NonInterleaved",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fastq.gzip": {
+      "file_ext_type": [
+        "FASTQ"
+      ],
+      "mappings": [
+        {
+          "id": "fastq_reads_interleaved",
+          "title": "FastQ Reads Interleaved",
+          "app_weight": 1
+        },
+        {
+          "id": "fastq_reads_noninterleaved",
+          "title": "FastQ Reads NonInterleaved",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fna": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fna.gz": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fna.gzip": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fa": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fa.gz": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fa.gzip": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "faa": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "faa.gz": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "faa.gzip": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fsa": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fsa.gz": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fsa.gzip": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fasta": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fasta.gz": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "fasta.gzip": {
+      "file_ext_type": [
+        "FASTA"
+      ],
+      "mappings": [
+        {
+          "id": "assembly",
+          "title": "Assembly",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff.gz": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff.gzip": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff2": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff2.gz": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff2.gzip": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff3": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff3.gz": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gff3.gzip": {
+      "file_ext_type": [
+        "GFF"
+      ],
+      "mappings": [
+        {
+          "id": "gff_genome",
+          "title": "GFF/FASTA Genome",
+          "app_weight": 1
+        },
+        {
+          "id": "gff_metagenome",
+          "title": "GFF/FASTA MetaGenome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gb": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gb.gz": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gb.gzip": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gbff": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gbff.gz": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gbff.gzip": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gbk": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gbk.gz": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gbk.gzip": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "genbank": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "genbank.gz": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "genbank.gzip": {
+      "file_ext_type": [
+        "GENBANK"
+      ],
+      "mappings": [
+        {
+          "id": "genbank_genome",
+          "title": "Genbank Genome",
+          "app_weight": 1
+        }
+      ]
+    },
+    "zip": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "tar": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "tgz": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "tar.gz": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "7z": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gz": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "gzip": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "rar": {
+      "file_ext_type": [
+        "CompressedFileFormatArchive"
+      ],
+      "mappings": [
+        {
+          "id": "decompress",
+          "title": "Decompress/Unpack",
+          "app_weight": 1
+        }
+      ]
+    },
+    "csv": {
+      "file_ext_type": [
+        "CSV"
+      ],
+      "mappings": [
+        {
+          "id": "sample_set",
+          "title": "Samples",
+          "app_weight": 1
+        }
+      ]
+    },
+    "xls": {
+      "file_ext_type": [
+        "EXCEL"
+      ],
+      "mappings": [
+        {
+          "id": "sample_set",
+          "title": "Samples",
+          "app_weight": 1
+        },
+        {
+          "id": "media",
+          "title": "Media",
+          "app_weight": 1
+        },
+        {
+          "id": "fba_model",
+          "title": "FBA Model",
+          "app_weight": 1
+        }
+      ]
+    },
+    "xlsx": {
+      "file_ext_type": [
+        "EXCEL"
+      ],
+      "mappings": [
+        {
+          "id": "sample_set",
+          "title": "Samples",
+          "app_weight": 1
+        },
+        {
+          "id": "media",
+          "title": "Media",
+          "app_weight": 1
+        },
+        {
+          "id": "fba_model",
+          "title": "FBA Model",
+          "app_weight": 1
+        }
+      ]
+    },
+    "tsv": {
+      "file_ext_type": [
+        "TSV"
+      ],
+      "mappings": [
+        {
+          "id": "media",
+          "title": "Media",
+          "app_weight": 1
+        },
+        {
+          "id": "expression_matrix",
+          "title": "Expression Matrix",
+          "app_weight": 1
+        },
+        {
+          "id": "metabolic_annotation",
+          "title": "Metabolic Annotations",
+          "app_weight": 1
+        },
+        {
+          "id": "metabolic_annotation_bulk",
+          "title": "Bulk Metabolic Annotations",
+          "app_weight": 1
+        },
+        {
+          "id": "fba_model",
+          "title": "FBA Model",
+          "app_weight": 1
+        },
+        {
+          "id": "phenotype_set",
+          "title": "Phenotype Set",
+          "app_weight": 1
+        }
+      ]
+    },
+    "smbl": {
+      "file_ext_type": [
+        "SBML"
+      ],
+      "mappings": [
+        {
+          "id": "fba_model",
+          "title": "FBA Model",
+          "app_weight": 1
+        }
+      ]
+    },
+    "json": {
+      "file_ext_type": [
+        "JSON"
+      ],
+      "mappings": [
+        {
+          "id": "escher_map",
+          "title": "EscherMap",
+          "app_weight": 1
+        }
+      ]
+    }
   }
 }

--- a/staging_service/AutoDetectUtils.py
+++ b/staging_service/AutoDetectUtils.py
@@ -2,33 +2,42 @@
 This class is in charge of determining possible importers by determining the suffix of the filepath pulled in,
 and by looking up the appropriate mappings in the supported_apps_w_extensions.json file
 """
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 
 
 class AutoDetectUtils:
     _MAPPINGS = None  # expects to be set by config
 
     @staticmethod
-    def determine_possible_importers(filename: str) -> Tuple[Optional[list], str, Optional[str]]:
+    def determine_possible_importers(filename: str) -> Tuple[Optional[list], Dict[str, object]]:
         """
         Given a filename, come up with a reference to all possible apps.
         :param filename: The filename to find applicable apps for
         :return: A tuple containing:
             a list of mapping references, or None if not found
-            the file prefix
-            the file suffix, if a suffix matched a mapping
+            The fileinfo dict, containing:
+                the file prefix
+                the file suffix, if a suffix matched a mapping
+                the file types, if a suffix matched a mapping, otherwise an empty list 
         """
         dotcount = filename.count(".")
         if dotcount:
             # preferentially choose the most specific suffix (e.g. longest)
             # to get file type mappings
+            m = AutoDetectUtils._MAPPINGS
             for i in range(1, dotcount + 1):
                 parts = filename.split(".", i)
                 suffix = parts[-1].lower()
-                if suffix in AutoDetectUtils._MAPPINGS["types"]:
+                if suffix in m["types"]:
                     prefix = ".".join(parts[0:i])
-                    return AutoDetectUtils._MAPPINGS["types"][suffix], prefix, parts[-1]
-        return None, filename, None
+                    return (
+                        m["types"][suffix]["mappings"],
+                        {"prefix": prefix,
+                         "suffix": parts[-1],
+                         "file_ext_type": m["types"][suffix]["file_ext_type"],
+                        }
+                    )
+        return None, {"prefix": filename, "suffix": None, "file_ext_type": []}
 
     @staticmethod
     def get_mappings(file_list: list) -> dict:
@@ -42,9 +51,9 @@ class AutoDetectUtils:
         mappings = []
         fileinfo = []
         for filename in file_list:
-            typemaps, prefix, suffix = AutoDetectUtils.determine_possible_importers(filename)
+            typemaps, fi = AutoDetectUtils.determine_possible_importers(filename)
             mappings.append(typemaps)
-            fileinfo.append({"prefix": prefix, "suffix": suffix})
+            fileinfo.append(fi)
         rv = {
             "mappings": mappings,
             "fileinfo": fileinfo,

--- a/staging_service/AutoDetectUtils.py
+++ b/staging_service/AutoDetectUtils.py
@@ -46,7 +46,7 @@ class AutoDetectUtils:
         :param file_list: A list of files
         :return: return a listing of apps, a listing of extension_mappings for each filename,
             and information about each file, currently the file prefix and the suffix used to
-            determine the mappings
+            determine the mappings and a list of file types.
         """
         mappings = []
         fileinfo = []

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -84,21 +84,25 @@ for filecat, apps in file_format_to_app_mapping.items():
 
 # with "genbank_genome" being the id of the matched app
 # and 1 being a perfect weight score of 100%
-extensions_mapping = defaultdict(list)
+extensions_mapping = {}
 for app_id in app_id_to_extensions:
 
     perfect_match_weight = 1
     for extension in app_id_to_extensions[app_id]:
-        extensions_mapping[extension].append(
-            {
-                "id": app_id,
-                "title": app_id_to_title[app_id],
-                "app_weight": perfect_match_weight,
+        if extension not in extensions_mapping:
+            extensions_mapping[extension] = {
                 # make a list to allow for expansion in the future - for example it could
                 # include whether reads are forward or reverse if we get smarter about name
                 # detection. For backwards compatibilily, we'd leave the current FASTQ type and
                 # add a FASTQ-FWD or FWD type or something.
-                "file_type": [extension_to_file_format_mapping[extension]],
+                "file_ext_type": [extension_to_file_format_mapping[extension]],
+                "mappings": []
+            }
+        extensions_mapping[extension]["mappings"].append(
+            {
+                "id": app_id,
+                "title": app_id_to_title[app_id],
+                "app_weight": perfect_match_weight,
             }
         )
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -975,7 +975,7 @@ async def test_importer_mappings():
         # Or we need to reload json file itself
 
         # unzip_mapping = AutoDetectUtils._MAPPINGS["apps"]["decompress/unpack"]
-        assert mappings[1][0] == AutoDetectUtils._MAPPINGS["types"]["gz"][0]
+        assert mappings[1][0] == AutoDetectUtils._MAPPINGS["types"]["gz"]["mappings"][0]
 
     # A dict is passed in
     data = {"file_list": [{}]}


### PR DESCRIPTION
- no reason to duplicate the file type in every mapping
- leaves the per mapping file_type field unused for future, more sophisticated file type algorithms