### PR TITLE
DATAUP_549: Add general parser framework

### DIFF
--- a/staging_service/import_specifications/file_parser.py
+++ b/staging_service/import_specifications/file_parser.py
@@ -221,5 +221,3 @@ def _parse(
         return ParseResults(errors=tuple(errors))
     else:
         return ParseResults(frozendict(results))
-        
-

--- a/tests/import_specifications/test_file_parser.py
+++ b/tests/import_specifications/test_file_parser.py
@@ -440,14 +440,14 @@ def test_parse_import_specification_multiple_specs_and_parser_error():
         Error(
             ErrorType.MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE,
             "data type bar appears in two importer specification sources",
-            SpecificationSource("b1"),
-            SpecificationSource("b2")
+            spcsrc("b1"),
+            spcsrc("b2")
         ),
         Error(
             ErrorType.MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE,
             "data type baz appears in two importer specification sources",
-            SpecificationSource("c1"),
-            SpecificationSource("c2")
+            spcsrc("c1"),
+            spcsrc("c2")
         )
     ]))
 

--- a/tests/import_specifications/test_file_parser.py
+++ b/tests/import_specifications/test_file_parser.py
@@ -347,7 +347,7 @@ def test_parse_import_specification_resolver_exception():
 
     resolver.assert_has_calls([call(Path("myfile.xlsx")), call(Path("somefile.csv"))])
     parser1.assert_called_once_with(Path("myfile.xlsx"))
-    # In [1]: ArithmeticError("a") == ArithmeticError("a")                            
+    # In [1]: ArithmeticError("a") == ArithmeticError("a")
     # Out[1]: False
     # so assert_called_once_with doesn't work
     assert_exception_correct(logger.call_args[0][0], ArithmeticError("crapsticks"))


### PR DESCRIPTION
parsers for individual file types are provided by the resolver.