### PR TITLE
Type hint tuples correctly

### DIFF
--- a/staging_service/import_specifications/file_parser.py
+++ b/staging_service/import_specifications/file_parser.py
@@ -3,12 +3,13 @@ Parse import specifications files, either CSV, TSV, or Excel, and return the con
 error information.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 # TODO update to C impl when fixed: https://github.com/Marco-Sulla/python-frozendict/issues/26
 from frozendict.core import frozendict
 from pathlib import Path
-from typing import Union, Callable, Optional as O
+from typing import Union, Optional as O
 
 # TODO should get mypy working at some point
 

--- a/staging_service/import_specifications/file_parser.py
+++ b/staging_service/import_specifications/file_parser.py
@@ -112,7 +112,7 @@ class ParseResult:
     parse_import_specifications method to create instances of this class.
     """
     source: SpecificationSource
-    result: tuple[frozendict[str, PRIMITIVE_TYPE]]
+    result: tuple[frozendict[str, PRIMITIVE_TYPE], ...]
 
     def __post_init__(self):
         if not self.source:
@@ -138,7 +138,7 @@ class ParseResults:
     parse_import_specifications method to create an instance of this class.
     """
     results: O[frozendict[str, ParseResult]] = None
-    errors: O[tuple[Error]] = None
+    errors: O[tuple[Error, ...]] = None
 
     def __post_init__(self):
         if not (bool(self.results) ^ bool(self.errors)):  # xnor
@@ -165,7 +165,7 @@ class FileTypeResolution:
 
 
 def parse_import_specifications(
-    paths: tuple[Path],
+    paths: tuple[Path, ...],
     file_type_resolver: Callable[[Path], FileTypeResolution],
     log_error: Callable[[Exception], None]
 ) -> ParseResults:
@@ -188,7 +188,7 @@ def parse_import_specifications(
         return ParseResults(errors=errors)
 
 def _parse(
-    paths: tuple[Path],
+    paths: tuple[Path, ...],
     file_type_resolver: Callable[[Path], FileTypeResolution],
 ) -> ParseResults:
     results = {}

--- a/tests/import_specifications/test_file_parser.py
+++ b/tests/import_specifications/test_file_parser.py
@@ -1,10 +1,11 @@
 # not much point in testing data classes unless there's custom logic in them
 
+from collections.abc import Callable
 from frozendict import frozendict
 from pytest import raises
 from tests.test_utils import assert_exception_correct
 from pathlib import Path
-from typing import Callable, Optional as O
+from typing import Optional as O
 from unittest.mock import Mock, call
 
 from staging_service.import_specifications.file_parser import (

--- a/tests/import_specifications/test_file_parser.py
+++ b/tests/import_specifications/test_file_parser.py
@@ -211,7 +211,7 @@ def test_ParseResult_init_fail():
 
 def parseResult_init_fail(
     source: O[SpecificationSource],
-    result: O[tuple[frozendict[str, PRIMITIVE_TYPE]]],
+    result: O[tuple[frozendict[str, PRIMITIVE_TYPE], ...]],
     expected: Exception
 ):
     with raises(Exception) as got:
@@ -257,7 +257,7 @@ def test_ParseResults_init_fail():
 
 def parseResults_init_fail(
     results: O[frozendict[str, ParseResult]],
-    errors: O[tuple[Error]],
+    errors: O[tuple[Error, ...]],
     expected: Exception
 ):
     with raises(Exception) as got:
@@ -268,7 +268,7 @@ def parseResults_init_fail(
 def _ftr(parser: Callable[[Path], ParseResults] = None, notype: str=None) -> FileTypeResolution:
     return FileTypeResolution(parser, notype)
 
-def _get_mocks(count: int) -> tuple[Mock]:
+def _get_mocks(count: int) -> tuple[Mock, ...]:
     return (Mock() for _ in range(count))
 
 


### PR DESCRIPTION
https://docs.python.org/3/library/typing.html#typing.Tuple

Also don't use the deprectated `Callable` type hint