### PR TITLE
DATAUP-549: Add an incorrect column count error type

### DIFF
--- a/staging_service/import_specifications/file_parser.py
+++ b/staging_service/import_specifications/file_parser.py
@@ -22,9 +22,10 @@ class ErrorType(Enum):
     """
     FILE_NOT_FOUND = 1
     PARSE_FAIL = 2
-    MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE = 3
-    NO_FILES_PROVIDED = 4
-    ILLEGAL_FILE_NAME = 5
+    INCORRECT_COLUMN_COUNT = 3
+    MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE = 4
+    NO_FILES_PROVIDED = 5
+    ILLEGAL_FILE_NAME = 6
     OTHER = 100
 
 
@@ -52,6 +53,7 @@ _ERR_SOURCE_2 = 'source_2'
 _ERRTYPE_TO_REQ_ARGS = {
     ErrorType.FILE_NOT_FOUND: (_ERR_SOURCE_1,),
     ErrorType.PARSE_FAIL: (_ERR_MESSAGE, _ERR_SOURCE_1),
+    ErrorType.INCORRECT_COLUMN_COUNT: (_ERR_MESSAGE, _ERR_SOURCE_1),
     ErrorType.MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE: (_ERR_MESSAGE, _ERR_SOURCE_1, _ERR_SOURCE_2),
     ErrorType.NO_FILES_PROVIDED: tuple(),
     ErrorType.ILLEGAL_FILE_NAME: (_ERR_MESSAGE,),
@@ -70,13 +72,14 @@ class Error:
 
     Each error type has different required arguments:
     {ErrorType.FILE_NOT_FOUND.name}: {_ERR_SOURCE_1}
-    {ErrorType.PARSE_FAIL}: {_ERR_MESSAGE} and {_ERR_SOURCE_1}
-    {ErrorType.MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE}: {_ERR_MESSAGE}, {_ERR_SOURCE_1}, and
+    {ErrorType.PARSE_FAIL.name}: {_ERR_MESSAGE} and {_ERR_SOURCE_1}
+    {ErrorType.INCORRECT_COLUMN_COUNT.name}: {_ERR_MESSAGE} and {_ERR_SOURCE_1}
+    {ErrorType.MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE.name}: {_ERR_MESSAGE}, {_ERR_SOURCE_1}, and
         {_ERR_SOURCE_2}
-    {ErrorType.NO_FILES_PROVIDED}: none
-    {ErrorType.ILLEGAL_FILE_NAME}: message. {_ERR_SOURCE_1} should be supplied if the file name
+    {ErrorType.NO_FILES_PROVIDED.name}: none
+    {ErrorType.ILLEGAL_FILE_NAME.name}: message. {_ERR_SOURCE_1} should be supplied if the file name
         is representable as a Path.
-    {ErrorType.OTHER}: {_ERR_MESSAGE}. source arguments are optional and may be included if
+    {ErrorType.OTHER.name}: {_ERR_MESSAGE}. source arguments are optional and may be included if
         the error applies to one or more source files.
 
     """

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -112,7 +112,7 @@ def _validate_xsv_row_count(path: Path, expected_count: int, sep: str):
                 # could collect errors (first 10?) and throw an exception with a list
                 # lets wait and see if that's really needed
                 raise _ParseException(Error(
-                    ErrorType.PARSE_FAIL,
+                    ErrorType.INCORRECT_COLUMN_COUNT,
                     f"Incorrect number of items in line {i + 2}, "
                     + f"expected {expected_count}, got {count}",
                     SpecificationSource(path)
@@ -174,7 +174,7 @@ def _parse_xsv(path: Path, sep: str) -> ParseResults:
         # ugh. https://github.com/pandas-dev/pandas/issues/43102
         # I really hope I'm not swallowing other pandas bugs here, but not really any way to tell
         return _error(Error(
-            ErrorType.PARSE_FAIL, "Header rows have unequal column counts", spcsrc
+            ErrorType.INCORRECT_COLUMN_COUNT, "Header rows have unequal column counts", spcsrc
         ))
 
 
@@ -214,7 +214,7 @@ def _process_excel_tab(excel: pandas.ExcelFile, spcsrc: SpecificationSource
     # Can't catch some header errors anyway, since pandas duplicates them silently
     if df.columns.shape[0] != columns:
         raise _ParseException(Error(
-            ErrorType.PARSE_FAIL,
+            ErrorType.INCORRECT_COLUMN_COUNT,
             f"Expected {columns} data columns, got {df.columns.shape[0]}",
             spcsrc,
         ))

--- a/tests/import_specifications/test_file_parser.py
+++ b/tests/import_specifications/test_file_parser.py
@@ -108,6 +108,15 @@ def test_Error_init_w_PARSE_FAIL_success():
     assert e.source_2 is None
 
 
+def test_Error_init_w_INCORRECT_COLUMN_COUNT_success():
+    e = Error(ErrorType.INCORRECT_COLUMN_COUNT, message="42", source_1=spcsrc("somefile"))
+
+    assert e.error == ErrorType.INCORRECT_COLUMN_COUNT
+    assert e.message == "42"
+    assert e.source_1 == spcsrc("somefile")
+    assert e.source_2 is None
+
+
 def test_Error_init_w_MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE_success():
     e = Error(
         ErrorType.MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE, "foo", spcsrc("foo2"), spcsrc("yay")
@@ -172,6 +181,9 @@ def test_Error_init_fail():
     err = "message, source_1 is required for a PARSE_FAIL error"
     error_init_fail(ErrorType.PARSE_FAIL, None, spcsrc("wooo"), None, ValueError(err))
     error_init_fail(ErrorType.PARSE_FAIL, "msg", None, None, ValueError(err))
+    err = "message, source_1 is required for a INCORRECT_COLUMN_COUNT error"
+    error_init_fail(ErrorType.INCORRECT_COLUMN_COUNT, None, spcsrc("whee"), None, ValueError(err))
+    error_init_fail(ErrorType.INCORRECT_COLUMN_COUNT, "msg", None, None, ValueError(err))
     ms = ErrorType.MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE
     err = ("message, source_1, source_2 is required for a "
         + "MULTIPLE_SPECIFICATIONS_FOR_DATA_TYPE error")


### PR DESCRIPTION
The idea behind this change is that the front end can provide detailed instructions re how to fix this error - e.g. look for an incorrect number of separators in xSV files or delete rows and columns outside the data block in Excel files.