### PR TITLE
DATAUP-603: Return file info along with results from bulk spec endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,14 +764,19 @@ Reponse:
 {
     "types": {
         <type 1>: [
-            {<spec.json ID 1: <value for ID, row 1>, <spec.json ID 2>: <value for ID, row 1>, ...},
-            {<spec.json ID 1: <value for ID, row 2>, <spec.json ID 2>: <value for ID, row 2>, ...},
+            {<spec.json ID 1>: <value for ID, row 1>, <spec.json ID 2>: <value for ID, row 1>, ...},
+            {<spec.json ID 1>: <value for ID, row 2>, <spec.json ID 2>: <value for ID, row 2>, ...},
             ...
         ],
         <type 2>: [
-            {<spec.json ID 1: <value for ID, row 1>, <spec.json ID 2>: <value for ID, row 1>, ...},
+            {<spec.json ID 1>: <value for ID, row 1>, <spec.json ID 2>: <value for ID, row 1>, ...},
             ...
         ],
+        ...
+    },
+    "files": {
+        <type 1>: {"file": "<username>/file1.<ext>", "tab": "tabname"},
+        <type 2>: {"file": "<username>/file2.<ext>", "tab": null},
         ...
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### Version 1.3.1
+- added the `files` key to the returned data from the `bulk_specification` endpoint.
+
 ### Version 1.3.0
 - Update to Python 3.9
 - Add `bulk_specification` endpoint for parsing import specifications

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -27,7 +27,7 @@ from .autodetect.Mappings import CSV, TSV, EXCEL
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 routes = web.RouteTableDef()
-VERSION = "1.3.0"
+VERSION = "1.3.1"
 
 _APP_JSON = "application/json"
 
@@ -92,8 +92,10 @@ async def bulk_specification(request: web.Request) -> web.json_response:
         _file_type_resolver,
         lambda e: logging.error("Unexpected error while parsing import specs", exc_info=e))
     if res.results:
-        t = {dt: result.result for dt, result in res.results.items()}
-        return web.json_response({"types": t})
+        types = {dt: result.result for dt, result in res.results.items()}
+        files = {dt: {"file": str(paths[result.source.file]), "tab": result.source.tab}
+            for dt, result in res.results.items()}
+        return web.json_response({"types": types, "files": files})
     errtypes = {e.error for e in res.errors}
     errtext = json.dumps({"errors": format_import_spec_errors(res.errors, paths)})
     if errtypes - {ErrorType.OTHER, ErrorType.FILE_NOT_FOUND}:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1052,23 +1052,33 @@ async def test_bulk_specification_success():
 
             resp = await cli.get(f"bulk_specification/?files={tsv}  ,   {csv},  {excel}   ")
             jsn = await resp.json()
-            assert jsn == {"types": {
-                "genomes": [
-                    {"spec1": "val1", "spec2": "ꔆ", "spec3": 7},
-                    {"spec1": "val3", "spec2": "val4", "spec3": 1}
-                ],
-                "breakfastcereals": [
-                    {"s1": "froot loops", "s2": "puffin", "s3": "gross"},
-                    {"s1": "grape nuts", "s2": "dietary fiber", "s3": "also gross"},
-                ],
-                "fruit_bats": [
-                    {"bat_name": "George", "wing_count": 42},
-                    {"bat_name": "Fred", "wing_count": 1.5},
-                ],
-                "tree_sloths": [
-                    {"entity_id": "That which ends all", "preferred_food": "ꔆ"}
-                ]
-            }}
+            assert jsn == {
+                "types": {
+                    "genomes": [
+                        {"spec1": "val1", "spec2": "ꔆ", "spec3": 7},
+                        {"spec1": "val3", "spec2": "val4", "spec3": 1}
+                    ],
+                    "breakfastcereals": [
+                        {"s1": "froot loops", "s2": "puffin", "s3": "gross"},
+                        {"s1": "grape nuts", "s2": "dietary fiber", "s3": "also gross"},
+                    ],
+                    "fruit_bats": [
+                        {"bat_name": "George", "wing_count": 42},
+                        {"bat_name": "Fred", "wing_count": 1.5},
+                    ],
+                    "tree_sloths": [
+                        {"entity_id": "That which ends all", "preferred_food": "ꔆ"}
+                    ]
+                },
+                "files": {
+                    "genomes": {"file": "testuser/genomes.tsv", "tab": None},
+                    "breakfastcereals": {
+                        "file": "testuser/somefolder/breakfastcereals.csv",
+                        "tab": None},
+                    "fruit_bats": {"file": "testuser/importspec.xlsx", "tab": "bats"},
+                    "tree_sloths": {"file": "testuser/importspec.xlsx", "tab": "sloths"},
+                }
+            }
             assert resp.status == 200
 
 


### PR DESCRIPTION
There were frequent requests in user testing xSV import to know which file the data was coming from when examining errors in the bulk import cell. This enables that functionality by providing the file names along with the results.