### PR TITLE
DATAUP-682: Add Excel import template writer

### DIFF
--- a/staging_service/import_specifications/file_writers.py
+++ b/staging_service/import_specifications/file_writers.py
@@ -158,7 +158,8 @@ def _write_xsv(folder: Path, types: dict[str, dict[str, list[Any]]], ext: str, s
     _check_write_args(folder, types)
     res = {}
     for datatype in types:
-        out = folder / (datatype + "." + ext)
+        file_ = datatype + "." + ext
+        out = folder / file_
         dt = types[datatype]
         cols = len(dt[_ORDER_AND_DISPLAY])
         with open(out, "w", newline='') as f:
@@ -170,7 +171,7 @@ def _write_xsv(folder: Path, types: dict[str, dict[str, list[Any]]], ext: str, s
             csvw.writerow([i[1] for i in dt[_ORDER_AND_DISPLAY]])
             for row in dt[_DATA]:
                 csvw.writerow([row[pid] for pid in pids])
-        res[datatype] = out
+        res[datatype] = file_
     return res
 
 
@@ -191,7 +192,8 @@ def write_excel(folder: Path, types: dict[str, dict[str, list[Any]]]) -> dict[st
     """
     _check_write_args(folder, types)
     res = {}
-    outfile = folder / (_IMPORT_SPEC_FILE_NAME + "." + _EXT_EXCEL)
+    file_ = _IMPORT_SPEC_FILE_NAME + "." + _EXT_EXCEL
+    outfile = folder / file_
     wb = Workbook()
     for datatype in types:
         dt = types[datatype]
@@ -210,7 +212,7 @@ def write_excel(folder: Path, types: dict[str, dict[str, list[Any]]]) -> dict[st
         _write_excel_row(sheet, 2, pids)
         sheet.row_dimensions[1].hidden = True
         sheet.row_dimensions[2].hidden = True
-        res[datatype] = outfile
+        res[datatype] = file_
     # trash the automatically created sheet
     wb.remove_sheet(wb[wb.sheetnames[0]])
     wb.save(outfile)

--- a/tests/import_specifications/test_file_writers.py
+++ b/tests/import_specifications/test_file_writers.py
@@ -17,7 +17,11 @@ from staging_service.import_specifications.file_writers import (
     ImportSpecWriteException,
 )
 
-from tests.test_utils import assert_exception_correct
+from tests.test_utils import (
+    assert_exception_correct,
+    check_file_contents,
+    check_excel_contents,
+)
 
 
 @fixture(scope="module")
@@ -72,7 +76,7 @@ def test_write_csv(temp_dir: Path):
         "type2": "type2.csv",
         "type3": "type3.csv",
     }
-    _check_contents(
+    check_file_contents(
         temp_dir / "type1.csv",
         [
             "Data type: type1; Columns: 3; Version: 1\n",
@@ -82,7 +86,7 @@ def test_write_csv(temp_dir: Path):
             "boo!,,56.78\n",
         ]
     )
-    _check_contents(
+    check_file_contents(
         temp_dir / "type2.csv",
         [
             "Data type: type2; Columns: 1; Version: 1\n",
@@ -92,7 +96,7 @@ def test_write_csv(temp_dir: Path):
             "0\n",
         ]
     )
-    _check_contents(
+    check_file_contents(
         temp_dir / "type3.csv",
         [
             "Data type: type3; Columns: 3; Version: 1\n",
@@ -109,7 +113,7 @@ def test_write_tsv(temp_dir: Path):
         "type2": "type2.tsv",
         "type3": "type3.tsv",
     }
-    _check_contents(
+    check_file_contents(
         temp_dir / "type1.tsv",
         [
             "Data type: type1; Columns: 3; Version: 1\n",
@@ -119,7 +123,7 @@ def test_write_tsv(temp_dir: Path):
             "boo!\t\t56.78\n",
         ]
     )
-    _check_contents(
+    check_file_contents(
         temp_dir / "type2.tsv",
         [
             "Data type: type2; Columns: 1; Version: 1\n",
@@ -129,7 +133,7 @@ def test_write_tsv(temp_dir: Path):
             "0\n",
         ]
     )
-    _check_contents(
+    check_file_contents(
         temp_dir / "type3.tsv",
         [
             "Data type: type3; Columns: 3; Version: 1\n",
@@ -137,11 +141,6 @@ def test_write_tsv(temp_dir: Path):
             "hey this\txsv is only\ta template\n",
         ]
     )
-
-
-def _check_contents(file: Path, lines: list[str]):
-    with open(file) as f:
-        assert f.readlines() == lines
 
 
 def test_write_excel(temp_dir: Path):
@@ -155,7 +154,7 @@ def test_write_excel(temp_dir: Path):
     }
     wb = openpyxl.load_workbook(p / "import_specification.xlsx")
     assert wb.sheetnames == ["type1", "type2", "type3"]
-    _check_excel_contents(
+    check_excel_contents(
         wb,
         "type1",
         [
@@ -167,7 +166,7 @@ def test_write_excel(temp_dir: Path):
         ],
         [16.0, 5.0, 15.0],
     )
-    _check_excel_contents(
+    check_excel_contents(
         wb,
         "type2",
         [
@@ -179,7 +178,7 @@ def test_write_excel(temp_dir: Path):
         ],
         [28.0],
     )
-    _check_excel_contents(
+    check_excel_contents(
         wb,
         "type3",
         [
@@ -189,20 +188,6 @@ def test_write_excel(temp_dir: Path):
         ],
         [8.0, 11.0, 10.0],
     )
-
-
-def _check_excel_contents(
-    wb: openpyxl.Workbook,
-    sheetname: str,
-    contents: list[list[Any]],
-    column_widths: list[int]
-):
-    sheet = wb[sheetname]
-    for i, row in enumerate(sheet.iter_rows()):
-        assert [cell.value for cell in row] == contents[i]
-    # presumably there's an easier way to do this, but it works so f it
-    dims = [sheet.column_dimensions[dim].width for dim in sheet.column_dimensions]
-    assert dims == column_widths
 
 
 def test_file_writers_fail():

--- a/tests/import_specifications/test_file_writers.py
+++ b/tests/import_specifications/test_file_writers.py
@@ -68,9 +68,9 @@ def test_noop():
 def test_write_csv(temp_dir: Path):
     res = write_csv(temp_dir, _TEST_DATA)
     assert res == {
-        "type1": temp_dir / "type1.csv",
-        "type2": temp_dir / "type2.csv",
-        "type3": temp_dir / "type3.csv",
+        "type1": "type1.csv",
+        "type2": "type2.csv",
+        "type3": "type3.csv",
     }
     _check_contents(
         temp_dir / "type1.csv",
@@ -105,9 +105,9 @@ def test_write_csv(temp_dir: Path):
 def test_write_tsv(temp_dir: Path):
     res = write_tsv(temp_dir, _TEST_DATA)
     assert res == {
-        "type1": temp_dir / "type1.tsv",
-        "type2": temp_dir / "type2.tsv",
-        "type3": temp_dir / "type3.tsv",
+        "type1": "type1.tsv",
+        "type2": "type2.tsv",
+        "type3": "type3.tsv",
     }
     _check_contents(
         temp_dir / "type1.tsv",
@@ -149,9 +149,9 @@ def test_write_excel(temp_dir: Path):
     os.makedirs(p, exist_ok=True)
     res = write_excel(p, _TEST_DATA)
     assert res == {
-        "type1": p / "import_specification.xlsx",
-        "type2": p / "import_specification.xlsx",
-        "type3": p / "import_specification.xlsx",
+        "type1": "import_specification.xlsx",
+        "type2": "import_specification.xlsx",
+        "type3": "import_specification.xlsx",
     }
     wb = openpyxl.load_workbook(p / "import_specification.xlsx")
     assert wb.sheetnames == ["type1", "type2", "type3"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,11 @@ import configparser
 import traceback
 
 from dotenv import load_dotenv
+from pathlib import Path
+from typing import Any
 import os
 
+import openpyxl
 
 def bootstrap():
     test_env_0 = "../test.env"
@@ -32,3 +35,20 @@ def assert_exception_correct(got: Exception, expected: Exception):
     err = "".join(traceback.TracebackException.from_exception(got).format())
     assert got.args == expected.args, err
     assert type(got) == type(expected)
+
+def check_file_contents(file: Path, lines: list[str]):
+    with open(file) as f:
+        assert f.readlines() == lines
+
+def check_excel_contents(
+    wb: openpyxl.Workbook,
+    sheetname: str,
+    contents: list[list[Any]],
+    column_widths: list[int]
+):
+    sheet = wb[sheetname]
+    for i, row in enumerate(sheet.iter_rows()):
+        assert [cell.value for cell in row] == contents[i]
+    # presumably there's an easier way to do this, but it works so f it
+    dims = [sheet.column_dimensions[dim].width for dim in sheet.column_dimensions]
+    assert dims == column_widths


### PR DESCRIPTION
Also modifies the return from the xSV writers to make it easier for calling methods to rewrite paths, e.g. full path -> staging service user path.