### PR TITLE
DATAUP-648: Add import_filetypes endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ data structure to that which the parse endpoint returns and writes bulk specific
 POST write_bulk_specification/
 {
     "output_directory": <staging area directory in which to write output files>,
-    "output_file_type": <one of "CSV", "TSV", or "Excel">,
+    "output_file_type": <one of "CSV", "TSV", or "EXCEL">,
     "types": {
         <type 1>: {
             "order_and_display: [
@@ -946,7 +946,7 @@ POST write_bulk_specification/
 * `<type N>` is a data type ID from the [Mappings.py](./staging_service/autodetect/Mappings.py)
   file and the Narrative staging area configuration file - it is a shared namespace between the
   staging service and Narrative to specify bulk applications, and has a 1:1 mapping to an
-  app. It is included inthe first header line in the templates.
+  app. It is included in the first header line in the templates.
 * `order_and_display` determines the ordering of the columns in the written templates, as well
   as mapping the spec.json ID of the parameter to the human readable name of the parameter in
   the display.yml file.
@@ -965,7 +965,7 @@ POST write_bulk_specification/
 Reponse:
 ```
 {
-    "output_file_type": <one of "CSV", "TSV", or "Excel">,
+    "output_file_type": <one of "CSV", "TSV", or "EXCEL">,
     "files": {
         <type 1>: <staging service path to file containg data for type 1>,
         ...
@@ -1066,6 +1066,53 @@ Response:
 ```
 must provide file_list field 
 ```
+
+## Get importer filetypes
+
+This endpoint returns information about the file types associated with data types and the file
+extensions for those file types. It is primarily of use for creating UI elements describing
+which file extensions may be selected when performing bulk file selections.
+
+**URL** : `ci.kbase.us/services/staging_service/importer_filetypes`
+
+**local URL** : `localhost:3000/importer_filetypes`
+
+**Method** : `GET`
+
+**Headers** : Not Required
+
+### Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+```
+GET importer_filetypes/
+```
+Response:
+```
+{
+    "datatype_to_filetype": {
+        <type 1>: [<file type 1>, ... <file type N>],
+        ...
+        <type M>: [<file type 1>, ... <file type N>],
+    },
+    "filetype_to_extensions": {
+        <file type 1>: [<extension 1>, ..., <extension N>],
+        ...
+        <file type M>: [<extension 1>, ..., <extension N>],
+    }
+}
+```
+
+* `<type N>` is a data type ID from the [Mappings.py](./staging_service/autodetect/Mappings.py)
+  file and the Narrative staging area configuration file - it is a shared namespace between the
+  staging service and Narrative to specify bulk applications, and has a 1:1 mapping to an
+  import app. It is included in the first header line in the templates.
+* `<file type N>` is a file type like `FASTA` or `GENBANK`. The supported file types are listed
+  below.
+* `<extension N>` is a file extension like `*.fa` or `*.gbk`.
 
 # Autodetect App and File Type IDs
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### Version 1.3.2
 - Add `write_bulk_specification` endpoint for writing bulk specifications
+- Add `import_filetypes` endpoint for getting datatype -> filetype -> extension mappings
 
 ### Version 1.3.1
 - added the `files` key to the returned data from the `bulk_specification` endpoint.

--- a/staging_service/import_specifications/file_writers.py
+++ b/staging_service/import_specifications/file_writers.py
@@ -136,8 +136,6 @@ def _check_is_sequence(tocheck: Any, errprefix: str):
         raise ImportSpecWriteException(errprefix + " is not a list")
 
 
-# TODO WRITE_XSV look into server OOM protection if the user sends a huge JSON packet
-
 def write_csv(folder: Path, types: dict[str, dict[str, list[Any]]]) -> dict[str, Path]:
     """
     Writes import specifications to 1 or more csv files. All the writers in this module

--- a/tests/import_specifications/test_file_writers.py
+++ b/tests/import_specifications/test_file_writers.py
@@ -6,7 +6,6 @@ import openpyxl
 from collections.abc import Generator
 from pathlib import Path
 from pytest import raises, fixture
-from typing import Any
 
 from tests.test_app import FileUtil
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1604,3 +1604,40 @@ async def test_write_bulk_specification_fail_invalid_type_value():
         {"output_directory": "foo", "output_file_type": "CSV", "types": {"a": "fake"}},
          "The value for data type a must be a mapping"
     )
+
+
+async def test_importer_filetypes():
+    """
+    Only checks a few example entries since the list may expand over time
+    """
+    async with AppClient(config) as cli:
+        resp = await cli.get("importer_filetypes/")
+        js = await resp.json()
+        assert set(js.keys()) == {"datatype_to_filetype", "filetype_to_extensions"}
+        a2f = js["datatype_to_filetype"]
+        assert a2f["assembly"] == ["FASTA"]
+        assert a2f["gff_genome"] == ["FASTA", "GFF"]
+        assert a2f["import_specification"] == ["CSV", "EXCEL", "TSV"]
+
+        f2e = js["filetype_to_extensions"]
+        assert f2e["FASTA"] == [
+            "fa",
+            "fa.gz",
+            "fa.gzip",
+            "faa",
+            "faa.gz",
+            "faa.gzip",
+            "fasta",
+            "fasta.gz",
+            "fasta.gzip",
+            "fna",
+            "fna.gz",
+            "fna.gzip",
+            "fsa",
+            "fsa.gz",
+            "fsa.gzip",
+        ]
+        assert f2e["EXCEL"] == ["xls", "xlsx"]
+        assert f2e["SRA"] == ["sra"]
+
+        assert resp.status == 200


### PR DESCRIPTION
This is to support the extension list in the popup dialog in that design ticket. Since I was already working on the staging service and this was a very simple endpoint I figured I'd implement it well ahead of of time.