### PR TITLE
DATAUP-691: Ignore blank lines in xSV files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 ### Version 1.3.2
 - Add `write_bulk_specification` endpoint for writing bulk specifications
 - Add `import_filetypes` endpoint for getting datatype -> filetype -> extension mappings
+- Fixed a bug in the csv/tsv bulk specification parser that would throw an error on any empty
+  lines in the file, even at the end. The parser now ignores empty lines the same way the Excel
+  parser does.
 
 ### Version 1.3.1
 - added the `files` key to the returned data from the `bulk_specification` endpoint.

--- a/staging_service/import_specifications/file_writers.py
+++ b/staging_service/import_specifications/file_writers.py
@@ -156,11 +156,10 @@ def _write_xsv(folder: Path, types: dict[str, dict[str, list[Any]]], ext: str, s
     _check_write_args(folder, types)
     res = {}
     for datatype in types:
-        file_ = datatype + "." + ext
-        out = folder / file_
+        filename = datatype + "." + ext
         dt = types[datatype]
         cols = len(dt[_ORDER_AND_DISPLAY])
-        with open(out, "w", newline='') as f:
+        with open(folder / filename, "w", newline='') as f:
             csvw = csv.writer(f, delimiter=sep)  # handle sep escaping
             csvw.writerow([f"{_DATA_TYPE} {datatype}{_HEADER_SEP} "
                            + f"{_COLUMN_STR} {cols}{_HEADER_SEP} {_VERSION_STR} {_VERSION}"])
@@ -169,7 +168,7 @@ def _write_xsv(folder: Path, types: dict[str, dict[str, list[Any]]], ext: str, s
             csvw.writerow([i[1] for i in dt[_ORDER_AND_DISPLAY]])
             for row in dt[_DATA]:
                 csvw.writerow([row[pid] for pid in pids])
-        res[datatype] = file_
+        res[datatype] = filename
     return res
 
 
@@ -190,8 +189,7 @@ def write_excel(folder: Path, types: dict[str, dict[str, list[Any]]]) -> dict[st
     """
     _check_write_args(folder, types)
     res = {}
-    file_ = _IMPORT_SPEC_FILE_NAME + "." + _EXT_EXCEL
-    outfile = folder / file_
+    filename = _IMPORT_SPEC_FILE_NAME + "." + _EXT_EXCEL
     wb = Workbook()
     for datatype in types:
         dt = types[datatype]
@@ -210,10 +208,10 @@ def write_excel(folder: Path, types: dict[str, dict[str, list[Any]]]) -> dict[st
         _write_excel_row(sheet, 2, pids)
         sheet.row_dimensions[1].hidden = True
         sheet.row_dimensions[2].hidden = True
-        res[datatype] = file_
+        res[datatype] = filename
     # trash the automatically created sheet
     wb.remove_sheet(wb[wb.sheetnames[0]])
-    wb.save(outfile)
+    wb.save(folder / filename)
     return res
 
 

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -101,10 +101,10 @@ def _check_for_duplicate_headers(
         seen.add(name)
 
 
-# This method expects to be called from the _parse_xsv method, and therefore
-# * The first header line has been parsed
-# * There are at least 2 header lines
 def _validate_xsv_row_count(path: Path, expected_count: int, sep: str):
+    # This method expects to be called from the _parse_xsv method, and therefore
+    # * The first header line has been parsed
+    # * There are at least 2 header lines
     with open(path) as input_:
         # since we parsed the first line in the main _parse_xsv method, just discard here
         next(input_)

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -101,22 +101,25 @@ def _check_for_duplicate_headers(
         seen.add(name)
 
 
+# This method expects to be called from the _parse_xsv method, and therefore
+# * The first header line has been parsed
+# * There are at least 2 header lines
 def _validate_xsv_row_count(path: Path, expected_count: int, sep: str):
     with open(path) as input_:
         # since we parsed the first line in the main _parse_xsv method, just discard here
         next(input_)
         for i, line in enumerate(input_):
-            # I suppose we could count-- if the last entry is whitespace but f it
-            count = 0 if not line.strip() else len(line.split(sep))
-            if count != expected_count:
-                # could collect errors (first 10?) and throw an exception with a list
-                # lets wait and see if that's really needed
-                raise _ParseException(Error(
-                    ErrorType.INCORRECT_COLUMN_COUNT,
-                    f"Incorrect number of items in line {i + 2}, "
-                    + f"expected {expected_count}, got {count}",
-                    SpecificationSource(path)
-                ))
+            if line.strip():  # skip empty lines
+                count = len(line.split(sep))
+                if count != expected_count:
+                    # could collect errors (first 10?) and throw an exception with a list
+                    # lets wait and see if that's really needed
+                    raise _ParseException(Error(
+                        ErrorType.INCORRECT_COLUMN_COUNT,
+                        f"Incorrect number of items in line {i + 2}, "
+                        + f"expected {expected_count}, got {count}",
+                        SpecificationSource(path)
+                    ))
 
 def _process_dataframe(df: pandas.DataFrame, spec_source: SpecificationSource, header_index=0
 ) -> ParseResult:


### PR DESCRIPTION
Even leaving a blank line at the end of a csv or tsv file will make the parser puke