### PR TITLE
DATAUP-698: Fix ?sv files with missing header items getting strange key names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@
 - Fixed a bug in the csv/tsv bulk specification parser that would throw an error on any empty
   lines in the file, even at the end. The parser now ignores empty lines the same way the Excel
   parser does.
+- Fixed a bug in the `bulk_specification` endpoint where a missing header item in an `*.?sv`
+  file would cause it to be replaced with a strange name.
+- As part of the above fix, some error message text has changed due to the rewrite of the
+  parser.
 
 ### Version 1.3.1
 - added the `files` key to the returned data from the `bulk_specification` endpoint.

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -105,7 +105,6 @@ def _error(error: Error) -> ParseResults:
 
 
 def _normalize_pandas(val: PRIMITIVE_TYPE) -> PRIMITIVE_TYPE:
-    # remove when pandas is completely out of this file
     if pandas.isna(val):  # NaN = missing values in pandas
         return None
     if isinstance(val, str):
@@ -128,7 +127,6 @@ def _normalize(val: str) -> PRIMITIVE_TYPE:
 def _check_for_duplicate_headers(
     headers: pandas.Index, spec_source: SpecificationSource, header_index=0
 ):
-    # remove when pandas is completely out of this file
     seen = set()
     for name in headers.get_level_values(header_index):
         if name in seen:
@@ -199,7 +197,8 @@ def _parse_xsv(path: Path, sep: str) -> ParseResults:
                         f"Incorrect number of items in line {i}, "
                         + f"expected {columns}, got {len(row)}",
                         spcsrc))
-                results.append({param_ids[j]: _normalize(row[j]) for j in range(len(row))})
+                results.append(frozendict(
+                    {param_ids[j]: _normalize(row[j]) for j in range(len(row))}))
         if not results:
             raise _ParseException(Error(
                 ErrorType.PARSE_FAIL, "No non-header data in file", spcsrc))
@@ -232,6 +231,7 @@ def _load_excel_tab_to_dataframe(excel: pandas.ExcelFile, spcsrc: SpecificationS
         # ugh. https://github.com/pandas-dev/pandas/issues/43143
         # I really hope I'm not swallowing other pandas bugs here, but not really
         # any way to tell
+        # Not fixed as of pandas 1.4.0
         raise _ParseException(Error(
             ErrorType.PARSE_FAIL, "Missing expected header rows", spcsrc
         ))

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -115,7 +115,12 @@ def _normalize_pandas(val: PRIMITIVE_TYPE) -> PRIMITIVE_TYPE:
     return val
 
 
-def _normalize(val: str) -> PRIMITIVE_TYPE:
+def _normalize_xsv(val: str) -> PRIMITIVE_TYPE:
+    # Since csv and tsv rows are all parsed as list[str], regardless of the actual type, we
+    # 1) strip any whitespace that might be left around the entries
+    # 2) convert to numbers if the string represents a number
+    # 3) return None for empty strings, indicating a missing value in the csv
+    # If there's a non-numerical string left we return that
     val = val.strip()
     try:
         num = float(val)
@@ -198,7 +203,7 @@ def _parse_xsv(path: Path, sep: str) -> ParseResults:
                         + f"expected {columns}, got {len(row)}",
                         spcsrc))
                 results.append(frozendict(
-                    {param_ids[j]: _normalize(row[j]) for j in range(len(row))}))
+                    {param_ids[j]: _normalize_xsv(row[j]) for j in range(len(row))}))
         if not results:
             raise _ParseException(Error(
                 ErrorType.PARSE_FAIL, "No non-header data in file", spcsrc))

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -142,7 +142,7 @@ def _check_for_duplicate_headers(
 
 def _normalize_headers(
     headers: list[str], line_number: int, spec_source: SpecificationSource
-):
+) -> list[str]:
     seen = set()
     ret = [s.strip() for s in headers]
     for i, name in enumerate(ret, start=1):
@@ -204,8 +204,8 @@ def _parse_xsv(path: Path, sep: str) -> ParseResults:
             raise _ParseException(Error(
                 ErrorType.PARSE_FAIL, "No non-header data in file", spcsrc))
         return ParseResults(frozendict(
-                    {datatype: ParseResult(spcsrc, tuple(results))}
-                ))
+            {datatype: ParseResult(spcsrc, tuple(results))}
+        ))
     except FileNotFoundError:
         return _error(Error(ErrorType.FILE_NOT_FOUND, source_1=spcsrc))
     except IsADirectoryError:


### PR DESCRIPTION
Pandas would replace missing header items with weird names like
`Unnamed: 2_level_0`. Pandas has enough quirks that it's not worth using it -
simpler to just use a low level csv parser.