### PR TITLE
DATAUP-727: Fix an import spec parse bug re trailing separators

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### Version 1.3.4
+- Fixed a bug in the csv/tsv bulk specification parser that would case a failure if the
+  first header of a file had trailing separators. This occurs if a csv/tsv file is opened and
+  saved by Excel.
+
 ### Version 1.3.3
 - Fixed a bug in the csv/tsv bulk specification parser that would include an empty entry for
   each empty line in the file.

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -34,7 +34,7 @@ from .autodetect.Mappings import CSV, TSV, EXCEL
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 routes = web.RouteTableDef()
-VERSION = "1.3.3"
+VERSION = "1.3.4"
 
 _DATATYPE_MAPPINGS = None
 

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -10,7 +10,7 @@ import re
 # TODO update to C impl when fixed: https://github.com/Marco-Sulla/python-frozendict/issues/26
 from frozendict.core import frozendict
 from pathlib import Path
-from typing import TextIO, Optional as O, Union, Any
+from typing import Optional as O, Union, Any
 
 from staging_service.import_specifications.file_parser import (
     PRIMITIVE_TYPE,

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -141,8 +141,6 @@ def _parse_xsv(path: Path, sep: str) -> ParseResults:
         filetype = magic.from_file(str(path), mime=True)
         if filetype not in _MAGIC_TEXT_FILES:
             return _error(Error(ErrorType.PARSE_FAIL, "Not a text file: " + filetype, spcsrc))
-        if magic.from_file(str(path), mime=True) not in _MAGIC_TEXT_FILES:
-            return _error(Error(ErrorType.PARSE_FAIL, "Not a text file", spcsrc))
         with open(path, newline='') as input_:
             rdr = csv.reader(input_, delimiter=sep)  # let parser handle quoting
             dthd = _csv_next(rdr, 1, None, spcsrc, "Missing data type / version header")

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -138,6 +138,9 @@ def _normalize_headers(
 def _parse_xsv(path: Path, sep: str) -> ParseResults:
     spcsrc = SpecificationSource(path)
     try:
+        filetype = magic.from_file(str(path), mime=True)
+        if filetype not in _MAGIC_TEXT_FILES:
+            return _error(Error(ErrorType.PARSE_FAIL, "Not a text file: " + filetype, spcsrc))
         if magic.from_file(str(path), mime=True) not in _MAGIC_TEXT_FILES:
             return _error(Error(ErrorType.PARSE_FAIL, "Not a text file", spcsrc))
         with open(path, newline='') as input_:

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -35,7 +35,7 @@ _EXPECTED_HEADER = (f"{_DATA_TYPE} <data_type>{_HEADER_SEP} "
 _HEADER_REGEX = re.compile(f"{_DATA_TYPE} (\\w+){_HEADER_SEP} "
     + f"{_COLUMN_STR} (\\d+){_HEADER_SEP} {_VERSION_STR} (\\d+)")
 
-_MAGIC_TEXT_FILES = {"text/plain", "inode/x-empty"}
+_MAGIC_TEXT_FILES = {"text/plain", "inode/x-empty", "application/csv"}
 
 
 class _ParseException(Exception):

--- a/staging_service/import_specifications/individual_parsers.py
+++ b/staging_service/import_specifications/individual_parsers.py
@@ -35,7 +35,7 @@ _EXPECTED_HEADER = (f"{_DATA_TYPE} <data_type>{_HEADER_SEP} "
 _HEADER_REGEX = re.compile(f"{_DATA_TYPE} (\\w+){_HEADER_SEP} "
     + f"{_COLUMN_STR} (\\d+){_HEADER_SEP} {_VERSION_STR} (\\d+)")
 
-_MAGIC_TEXT_FILES = {"text/plain", "inode/x-empty", "application/csv"}
+_MAGIC_TEXT_FILES = {"text/plain", "inode/x-empty", "application/csv", "text/csv"}
 
 
 class _ParseException(Exception):

--- a/tests/import_specifications/test_individual_parsers.py
+++ b/tests/import_specifications/test_individual_parsers.py
@@ -39,6 +39,9 @@ def temp_dir() -> Generator[Path, None, None]:
 
 
 def test_xsv_parse_success(temp_dir: Path):
+    # Tests a special case where if an xSV file is opened by Excel and then resaved, 
+    # Excel will add separators to the end of the 1st header line. This previously caused
+    # the parse to fail.
     _xsv_parse_success(temp_dir, ',', parse_csv)
     _xsv_parse_success(temp_dir, '\t', parse_tsv)
 
@@ -48,7 +51,7 @@ def _xsv_parse_success(temp_dir: Path, sep: str, parser: Callable[[Path], ParseR
     input_ = temp_dir / str(uuid.uuid4())
     with open(input_, "w") as test_file:
         test_file.writelines([
-            "Data type: some_type; Columns: 4; Version: 1\n",
+            f"Data type: some_type; Columns: 4; Version: 1{s}{s}{s}\n",
             f"spec1{s} spec2{s}   spec3   {s} spec4\n",    # test trimming
             f"Spec 1{s} Spec 2{s} Spec 3{s} Spec 4\n",
             f"val1 {s}   val2   {s}    7     {s} 3.2\n",   # test trimming

--- a/tests/import_specifications/test_individual_parsers.py
+++ b/tests/import_specifications/test_individual_parsers.py
@@ -169,7 +169,10 @@ def test_xsv_parse_fail_binary_file(temp_dir: Path):
     res = parse_csv(test_file)
 
     assert res == ParseResults(errors=tuple([
-        Error(ErrorType.PARSE_FAIL, "Not a text file", source_1=SpecificationSource(test_file))
+        Error(
+            ErrorType.PARSE_FAIL,
+            "Not a text file: application/vnd.ms-excel",
+            source_1=SpecificationSource(test_file))
     ]))
 
 


### PR DESCRIPTION
If an xSV file is opened and saved by Excel, it'll add trailing separators to
the end of the first header line. This fix ignores those separators.