### PR TITLE
DATAUP-746: empty `types` dictionary throws an error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### Version 1.3.5
+- Alter the behavior of the bulk specification file writers to return an error if the
+  input `types` parameter is empty.
+
 ### Version 1.3.4
 - Fixed a bug in the csv/tsv bulk specification parser that would case a failure if the
   first header of a file had trailing separators. This occurs if a csv/tsv file is opened and

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -34,7 +34,7 @@ from .autodetect.Mappings import CSV, TSV, EXCEL
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 routes = web.RouteTableDef()
-VERSION = "1.3.4"
+VERSION = "1.3.5"
 
 _DATATYPE_MAPPINGS = None
 
@@ -59,7 +59,7 @@ async def importer_filetypes(request: web.Request) -> web.json_response:
     Returns the file types for the configured datatypes. The returned JSON contains two keys:
     * datatype_to_filetype, which maps import datatypes (like gff_genome) to their accepted
       filetypes (like [FASTA, GFF])
-    * filetype_to_extensions, which maps file types (e.g. FASTA) to their extensions (e.g. 
+    * filetype_to_extensions, which maps file types (e.g. FASTA) to their extensions (e.g.
       *.fa, *.fasta, *.fa.gz, etc.)
 
     This information is currently static over the life of the server.
@@ -197,7 +197,7 @@ async def write_bulk_specification(request: web.Request) -> web.json_response:
 def _createJSONErrorResponse(error_text: str, error_class=web.HTTPBadRequest):
     err = json.dumps({"error": error_text})
     return error_class(text=err, content_type=_APP_JSON)
-    
+
 
 @routes.get("/add-acl-concierge")
 async def add_acl_concierge(request: web.Request):

--- a/staging_service/import_specifications/file_writers.py
+++ b/staging_service/import_specifications/file_writers.py
@@ -23,7 +23,7 @@ All the write_* functions in this module have the same function signature:
         entry in the list corresponds to a row in the resulting import specification,
         and the order of the list defines the order of the rows.
     Leave the `data` list empty to write an empty template.
-:returns: A mapping of the data types to the files to which they were written. 
+:returns: A mapping of the data types to the files to which they were written.
 """
 # note that we can't use an f string here to interpolate the variables below, e.g.
 # order_and_display, etc.
@@ -82,7 +82,7 @@ def _check_import_specification(types: dict[str, dict[str, list[Any]]]):
         Leave the {_DATA} list empty to write an empty template.
     """
     if not types:
-        return
+        raise ImportSpecWriteException("At least one data type must be specified")
     for datatype in types:
         # replace this with jsonschema? don't worry about it for now
         _check_string(datatype, "A data type")

--- a/tests/import_specifications/test_file_writers.py
+++ b/tests/import_specifications/test_file_writers.py
@@ -64,9 +64,6 @@ _TEST_DATA = {
     }
 }
 
-def test_noop():
-    assert write_csv(Path("."), {}) == {}
-    assert write_tsv(Path("."), {}) == {}
 
 def test_write_csv(temp_dir: Path):
     res = write_csv(temp_dir, _TEST_DATA)

--- a/tests/import_specifications/test_file_writers.py
+++ b/tests/import_specifications/test_file_writers.py
@@ -194,6 +194,7 @@ def test_file_writers_fail():
     E = ImportSpecWriteException
     file_writers_fail(None, {}, ValueError("The folder cannot be null"))
     file_writers_fail(p, None, E("The types value must be a mapping"))
+    file_writers_fail(p, {}, E("At least one data type must be specified"))
     file_writers_fail(
         p, {None: 1}, E("A data type cannot be a non-string or a whitespace only string"))
     file_writers_fail(


### PR DESCRIPTION
Ensure that the file writer throws an error if the types parameter is empty.