### PR TITLE
Merge versions to 1.3.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,6 @@
-### Version 1.3.5
+### Version 1.3.4
 - Alter the behavior of the bulk specification file writers to return an error if the
   input `types` parameter is empty.
-
-### Version 1.3.4
 - Fixed a bug in the csv/tsv bulk specification parser that would case a failure if the
   first header of a file had trailing separators. This occurs if a csv/tsv file is opened and
   saved by Excel.

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -34,7 +34,7 @@ from .autodetect.Mappings import CSV, TSV, EXCEL
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 routes = web.RouteTableDef()
-VERSION = "1.3.5"
+VERSION = "1.3.4"
 
 _DATATYPE_MAPPINGS = None
 


### PR DESCRIPTION
1.3.4 was never deployed to CI, let alone prod, so no need for another
version bump