### PR TITLE
Fix config

### DIFF
--- a/deployment/conf/deployment.cfg
+++ b/deployment/conf/deployment.cfg
@@ -4,4 +4,4 @@ DATA_DIR = /kb/deployment/lib/src/data/bulk/
 AUTH_URL = https://ci.kbase.us/services/auth/api/V2/token
 CONCIERGE_PATH = /kbaseconcierge
 FILE_EXTENSION_MAPPINGS = /kb/deployment/conf/supported_apps_w_extensions.json
-DTS_MANIFEST_SCHEMA = /kb/deployment/import_specifications/schema/dts_manifest_schema.json
+DTS_MANIFEST_SCHEMA = /kb/module/import_specifications/schema/dts_manifest_schema.json


### PR DESCRIPTION
The deployment config had an incorrect path that wasn't caught in automated testing.

A future PR should include a GHA test of the built image.

This needs to be followed up with a merge from `dts-manifest-schema` -> `develop`. That code was all validated and vetted, just needs merged.