### PR TITLE
Adjust file mappings

### DIFF
--- a/deployment/conf/supported_apps_w_extensions.json
+++ b/deployment/conf/supported_apps_w_extensions.json
@@ -121,8 +121,7 @@
       "csv",
       "tsv",
       "xls",
-      "xlsx",
-      "json"
+      "xlsx"
     ],
     "media": [
       "tsv",
@@ -148,6 +147,9 @@
       "tsv"
     ],
     "escher_map": [
+      "json"
+    ],
+    "dts_manifest": [
       "json"
     ]
   },
@@ -1102,23 +1104,6 @@
         }
       ]
     },
-    "json": {
-      "file_ext_type": [
-        "JSON"
-      ],
-      "mappings": [
-        {
-          "id": "import_specification",
-          "title": "Import Specification",
-          "app_weight": 1
-        },
-        {
-          "id": "escher_map",
-          "title": "EscherMap",
-          "app_weight": 1
-        }
-      ]
-    },
     "smbl": {
       "file_ext_type": [
         "SBML"
@@ -1127,6 +1112,23 @@
         {
           "id": "fba_model",
           "title": "FBA Model",
+          "app_weight": 1
+        }
+      ]
+    },
+    "json": {
+      "file_ext_type": [
+        "JSON"
+      ],
+      "mappings": [
+        {
+          "id": "escher_map",
+          "title": "EscherMap",
+          "app_weight": 1
+        },
+        {
+          "id": "dts_manifest",
+          "title": "Data Transfer Service Manifest",
           "app_weight": 1
         }
       ]

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -50,6 +50,7 @@ from staging_service.autodetect.Mappings import (
     ZIP,
     assembly_id,
     decompress_id,
+    dts_manifest,
     escher_map_id,
     expression_matrix_id,
     extension_to_file_format_mapping,
@@ -90,6 +91,7 @@ app_id_to_title = {
     phenotype_set_id: "Phenotype Set",
     escher_map_id: "EscherMap",
     import_specification: "Import Specification",
+    dts_manifest: "Data Transfer Service Manifest"
 }
 
 file_format_to_app_mapping = {}
@@ -129,7 +131,7 @@ file_format_to_app_mapping[EXCEL] = [
     fba_model_id,
     import_specification,
 ]
-file_format_to_app_mapping[JSON] = [escher_map_id, import_specification]
+file_format_to_app_mapping[JSON] = [escher_map_id, dts_manifest]
 file_format_to_app_mapping[SBML] = [fba_model_id]
 
 app_id_to_extensions = defaultdict(list)

--- a/staging_service/autodetect/GenerateMappings.py
+++ b/staging_service/autodetect/GenerateMappings.py
@@ -91,7 +91,7 @@ app_id_to_title = {
     phenotype_set_id: "Phenotype Set",
     escher_map_id: "EscherMap",
     import_specification: "Import Specification",
-    dts_manifest: "Data Transfer Service Manifest"
+    dts_manifest: "Data Transfer Service Manifest",
 }
 
 file_format_to_app_mapping = {}

--- a/staging_service/autodetect/Mappings.py
+++ b/staging_service/autodetect/Mappings.py
@@ -51,6 +51,10 @@ sample_set_id = "sample_set"
 # import_specification is not a "real" data type, but rather tells the narrative that the
 # file contains specifications for how to load one or more other staging area files.
 import_specification = "import_specification"
+# dts_manifest is also not a real data type, but functions like import_specification as
+# it tells the narrative that the file has specs for loading other staging area files
+# that came from the Data Transfer Service, and that this manifest follows that spec.
+dts_manifest = "dts_manifest"
 decompress_id = "decompress"
 metabolic_annotations_id = "metabolic_annotation"
 metabolic_annotations_bulk_id = "metabolic_annotation_bulk"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1898,7 +1898,8 @@ async def test_importer_filetypes():
         a2f = js["datatype_to_filetype"]
         assert a2f["assembly"] == ["FASTA"]
         assert a2f["gff_genome"] == ["FASTA", "GFF"]
-        assert a2f["import_specification"] == ["CSV", "EXCEL", "JSON", "TSV"]
+        assert a2f["import_specification"] == ["CSV", "EXCEL", "TSV"]
+        assert a2f["dts_manifest"] == ["JSON"]
 
         f2e = js["filetype_to_extensions"]
         assert f2e["FASTA"] == [


### PR DESCRIPTION
Early in the DTS development, we mapped JSON files to the bulk import spec manager. Later, we decided that bulk import specs as JSON files could have multiple formats in the future. While the currently developed DTS manifest.json files do use the `import_specification` endpoint, just giving the front end the "import specification" mapping isn't enough information to properly form the request.

Therefore, this change removes the JSON mapping from `import_specification` and moves it to the new `dts_manifest`, which is more clear for both the front end consumer and the user.