### PR TITLE
CE-394 Update auth client usage, test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to run inside docker run /run_in_docker.sh
 -  to test use `./run_tests.sh`
 -  requires python 3.11.4 or higher
 -  requires installation on mac of libmagic: `brew install libmagic` or `sudo port install libmagic`.
--  auth client testing requires a KBase CI auth token (or wherever configured) and KBase user id. These should be in environment variables `KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
+-  testing requires a KBase CI auth token (or wherever configured in `deployment/conf/testing.cfg`) and KBase user id. These should be in environment variables `KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
 
 ## debugging
 

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -604,12 +604,11 @@ async def authorize_request(request):
     else:
         # this is a hack for prod because kbase_session won't get shared with the kbase.us domain
         token = request.cookies.get("kbase_session_backup")
+    if not token or not token.strip():
+        raise web.HTTPUnauthorized(text="must provide an auth token")
     try:
         username = await auth_client.get_user(token)
-    # TODO: ValueError is raised if there's no token - this should be checked before
-    # calling the auth client, but it currently breaks lots of tests because of
-    # how the auth call is mocked. See https://github.com/kbase/staging_service/issues/221
-    except (ValueError, InvalidTokenError) as err:
+    except InvalidTokenError as err:
         raise web.HTTPUnauthorized(text=str(err))
     except Exception as err:
         # catches edge case IOErrors and anything else that might pop up

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,6 +27,9 @@ import staging_service.utils as utils
 from staging_service.AutoDetectUtils import AutoDetectUtils
 from tests.test_utils import check_excel_contents, check_file_contents
 
+TEST_TOKEN = os.environ.get("KBASE_TEST_TOKEN")
+TEST_USER = os.environ.get("KBASE_TEST_USER")
+
 if os.environ.get("KB_DEPLOYMENT_CONFIG") is None:
     from tests.test_utils import bootstrap
 
@@ -64,15 +67,8 @@ def asyncgiven(**kwargs):
     return real_decorator
 
 
-async def mock_auth_app(config: configparser.ConfigParser, mock_username: str):
+async def mock_globus_app(config: configparser.ConfigParser, mock_username: str):
     application = await app.app_factory(config)
-
-    # this might break if the auth api changes
-    # TODO: add test auth token and user here
-    async def mock_get_user(*args, **kwargs):
-        return mock_username
-
-    app.auth_client.get_user = mock_get_user
 
     async def mock_globus_id(*args, **kwargs):
         return ["testuser@globusid.org"]
@@ -83,19 +79,29 @@ async def mock_auth_app(config: configparser.ConfigParser, mock_username: str):
 
 class AppClient:
     @classmethod
-    async def create(cls, config, mock_username=None):
-        if mock_username is None:
-            mock_username = "testuser"
-        app = await mock_auth_app(config, mock_username)
+    async def create(cls, config: configparser.ConfigParser, auth_token: str | None) -> "AppClient":
+        """
+        Creating this with an auth token sets the headers call by default to use the
+        provided auth token in the Authorization header.
+        If you want to make a call with a different header, you can
+        do so by setting headers directly in the call.
+        """
+        app = await mock_globus_app(config, auth_token)
         server = test_utils.TestServer(app)
-        return AppClient(server)
+        return AppClient(server, auth_token)
 
-    def __init__(self, server: test_utils.TestServer):
+    def __init__(self, server: test_utils.TestServer, auth_token: str | None):
         self.server = server
+        self.auth_token = auth_token
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> test_utils.TestClient:
         await self.server.start_server(loop=asyncio.get_event_loop())
-        self.client = test_utils.TestClient(self.server, loop=asyncio.get_event_loop())
+        headers = {}
+        if self.auth_token is not None:
+            headers["Authorization"] = self.auth_token
+        self.client = test_utils.TestClient(
+            self.server, loop=asyncio.get_event_loop(), headers=headers
+        )
         return self.client
 
     async def __aexit__(self, *args):
@@ -200,35 +206,31 @@ async def test_cmd(txt):
 
 
 async def test_auth():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.get("/test-auth")
         assert resp.status == 200
         text = await resp.text()
-        assert "I'm authenticated as" in text
+        assert f"I'm authenticated as {TEST_USER}" in text
 
 
 async def test_service():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.get("/test-service")
         assert resp.status == 200
         text = await resp.text()
         assert "staging service version" in text
 
 
-async def test_jbi_metadata():
+async def test_jgi_metadata():
     txt = "testing text\n"
-    username = "testuser"
-    jbi_metadata = '{"file_owner": "sdm", "added_date": "2013-08-12T00:21:53.844000"}'
+    jgi_metadata = '{"file_owner": "sdm", "added_date": "2013-08-12T00:21:53.844000"}'
 
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_jgi.fastq"), txt)
-            fs.make_file(os.path.join(username, "test", ".test_jgi.fastq.jgi"), jbi_metadata)
-            res1 = await cli.get(
-                os.path.join("jgi-metadata", "test", "test_jgi.fastq"),
-                headers={"Authorization": ""},
-            )
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_jgi.fastq"), txt)
+            fs.make_file(os.path.join(TEST_USER, "test", ".test_jgi.fastq.jgi"), jgi_metadata)
+            res1 = await cli.get(os.path.join("jgi-metadata", "test", "test_jgi.fastq"))
             assert res1.status == 200
             json_text = await res1.text()
             json = decoder.decode(json_text)
@@ -239,23 +241,18 @@ async def test_jbi_metadata():
 
             # testing non-existing jbi metadata file
             res1 = await cli.get(
-                os.path.join("jgi-metadata", "test", "non_existing.1617.2.1467.fastq"),
-                headers={"Authorization": ""},
+                os.path.join("jgi-metadata", "test", "non_existing.1617.2.1467.fastq")
             )
             assert res1.status == 404
 
 
 async def test_metadata():
     txt = "testing text\n"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
-            res1 = await cli.get(
-                os.path.join("metadata", "test", "test_file_1"),
-                headers={"Authorization": ""},
-            )
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
+            res1 = await cli.get(os.path.join("metadata", "test", "test_file_1"))
             assert res1.status == 200
             json_text = await res1.text()
             json = decoder.decode(json_text)
@@ -284,7 +281,6 @@ async def test_metadata():
             # testing existing metadata file
             res2 = await cli.get(
                 os.path.join("metadata", "test", "test_file_1"),
-                headers={"Authorization": ""},
             )
             assert res2.status == 200
             json_text = await res2.text()
@@ -312,12 +308,11 @@ async def test_metadata():
             assert not json.get("isFolder")
 
             # testing corrupted metadata file
-            path = os.path.join(META_DIR, username, "test", "test_file_1")
+            path = os.path.join(META_DIR, TEST_USER, "test", "test_file_1")
             with open(path, encoding="utf-8", mode="w") as f:
                 f.write('{"source": "Unknown"}')
             res3 = await cli.get(
                 os.path.join("metadata", "test", "test_file_1"),
-                headers={"Authorization": ""},
             )
             assert res3.status == 200
             json_text = await res3.text()
@@ -347,22 +342,19 @@ async def test_metadata():
 
 async def test_define_upa():
     txt = "testing text\n"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
             # generating metadata file
             res1 = await cli.get(
                 os.path.join("metadata", "test", "test_file_1"),
-                headers={"Authorization": ""},
             )
             assert res1.status == 200
 
             # posting UPA
             res2 = await cli.post(
                 os.path.join("define-upa", "test", "test_file_1"),
-                headers={"Authorization": ""},
                 data={"UPA": "test_UPA"},
             )
             assert res2.status == 200
@@ -372,7 +364,6 @@ async def test_define_upa():
             # getting new metadata
             res3 = await cli.get(
                 os.path.join("metadata", "test", "test_file_1"),
-                headers={"Authorization": ""},
             )
             assert res3.status == 200
             json_text = await res3.text()
@@ -405,22 +396,17 @@ async def test_define_upa():
             # testing non-existing jbi metadata file
             res4 = await cli.post(
                 os.path.join("define-upa", "test", "non_existing.test_file_1"),
-                headers={"Authorization": ""},
                 data={"UPA": "test_UPA"},
             )
             assert res4.status == 404
 
             # testing missing body
-            res5 = await cli.post(
-                os.path.join("define-upa", "test", "test_file_1"),
-                headers={"Authorization": ""},
-            )
+            res5 = await cli.post(os.path.join("define-upa", "test", "test_file_1"))
             assert res5.status == 400
 
             # testing missing UPA in body
             res6 = await cli.post(
                 os.path.join("define-upa", "test", "test_file_1"),
-                headers={"Authorization": ""},
                 data={"missing_UPA": "test_UPA"},
             )
             assert res6.status == 400
@@ -428,14 +414,15 @@ async def test_define_upa():
 
 async def test_mv():
     txt = "testing text\n"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
 
             # list current test directory
-            res1 = await cli.get(os.path.join("list", "test"), headers={"Authorization": ""})
+            res1 = await cli.get(
+                os.path.join("list", "test"),
+            )
             assert res1.status == 200
             json_text = await res1.text()
             json = decoder.decode(json_text)
@@ -444,7 +431,6 @@ async def test_mv():
 
             res2 = await cli.patch(
                 os.path.join("mv", "test", "test_file_1"),
-                headers={"Authorization": ""},
                 data={"newPath": "test/test_file_2"},
             )
             assert res2.status == 200
@@ -452,29 +438,24 @@ async def test_mv():
             assert "successfully moved" in json_text
 
             # relist test directory
-            res3 = await cli.get(os.path.join("list", "test"), headers={"Authorization": ""})
+            res3 = await cli.get(
+                os.path.join("list", "test"),
+            )
             assert res3.status == 200
             json_text = await res3.text()
             json = decoder.decode(json_text)
             assert len(json) == 1
             assert json[0]["name"] == "test_file_2"
 
-            # testing moving root
-            # res4 = await cli.patch('/mv',
-            #                        headers={'Authorization': ''},
-            #                        data={'newPath': 'test/test_file_2'})
-            # assert res4.status == 403
-
             # testing missing body
             res5 = await cli.patch(
-                os.path.join("mv", "test", "test_file_1"), headers={"Authorization": ""}
+                os.path.join("mv", "test", "test_file_1"),
             )
             assert res5.status == 400
 
             # testing missing newPath in body
             res6 = await cli.patch(
                 os.path.join("mv", "test", "test_file_1"),
-                headers={"Authorization": ""},
                 data={"missing_newPath": "test/test_file_2"},
             )
             assert res6.status == 400
@@ -482,7 +463,6 @@ async def test_mv():
             # testing moving to existing file
             res7 = await cli.patch(
                 os.path.join("mv", "test", "test_file_2"),
-                headers={"Authorization": ""},
                 data={"newPath": "test/test_file_2"},
             )
             assert res7.status == 409
@@ -490,7 +470,6 @@ async def test_mv():
             # testing non-existing file
             res7 = await cli.patch(
                 os.path.join("mv", "test", "non_existing.test_file_2"),
-                headers={"Authorization": ""},
                 data={"newPath": "test/test_file_2"},
             )
             assert res7.status == 404
@@ -498,14 +477,15 @@ async def test_mv():
 
 async def test_delete():
     txt = "testing text\n"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
 
             # list current test directory
-            res1 = await cli.get(os.path.join("list", "test"), headers={"Authorization": ""})
+            res1 = await cli.get(
+                os.path.join("list", "test"),
+            )
             assert res1.status == 200
             json_text = await res1.text()
             json = decoder.decode(json_text)
@@ -514,77 +494,70 @@ async def test_delete():
 
             res2 = await cli.delete(
                 os.path.join("delete", "test", "test_file_1"),
-                headers={"Authorization": ""},
             )
             assert res2.status == 200
             json_text = await res2.text()
             assert "successfully deleted" in json_text
 
             # relist test directory
-            res3 = await cli.get(os.path.join("list", "test"), headers={"Authorization": ""})
+            res3 = await cli.get(
+                os.path.join("list", "test"),
+            )
             assert res3.status == 200
             json_text = await res3.text()
             json = decoder.decode(json_text)
             assert len(json) == 0
 
-            # testing moving root
-            # res4 = await cli.delete('/delete/',
-            #                         headers={'Authorization': ''})
-            # assert res4.status == 403
-
             # testing non-existing file
             res5 = await cli.delete(
                 os.path.join("delete", "test", "non_existing.test_file_2"),
-                headers={"Authorization": ""},
             )
             assert res5.status == 404
 
 
 async def test_list():
     txt = "testing text"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
-            fs.make_dir(os.path.join(username, "test", "test_sub_dir"))
-            fs.make_file(os.path.join(username, "test", "test_sub_dir", "test_file_2"), txt)
-            res1 = await cli.get("list/..", headers={"Authorization": ""})
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test", "test_sub_dir"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_sub_dir", "test_file_2"), txt)
+            res1 = await cli.get("list/..")
             assert res1.status == 404
             res2 = await cli.get(
                 os.path.join("list", "test", "test_file_1"),
-                headers={"Authorization": ""},
             )
             assert res2.status == 400
 
             # testing root directory with 'list/' routes
-            res3 = await cli.get("/list/", headers={"Authorization": ""})
+            res3 = await cli.get("/list/")
             assert res3.status == 200
             json_text = await res3.text()
             json = decoder.decode(json_text)
             file_folder_count = [file_json["isFolder"] for file_json in json]
             assert json[0]["isFolder"] is True
             assert json[0]["name"] == "test"
-            assert json[0]["path"] == "testuser/test"
+            assert json[0]["path"] == f"{TEST_USER}/test"
             assert json[0]["mtime"] <= time.time() * 1000
             assert len(file_folder_count) == 4  # 2 folders and 2 files
             assert sum(file_folder_count) == 2
 
             # testing root directory with 'list' route
-            res4 = await cli.get("/list", headers={"Authorization": ""})
+            res4 = await cli.get("/list")
             assert res4.status == 200
             json_text = await res4.text()
             json = decoder.decode(json_text)
             file_folder_count = [file_json["isFolder"] for file_json in json]
             assert json[0]["isFolder"] is True
             assert json[0]["name"] == "test"
-            assert json[0]["path"] == "testuser/test"
+            assert json[0]["path"] == f"{TEST_USER}/test"
             assert json[0]["mtime"] <= time.time() * 1000
             assert len(file_folder_count) == 4  # 2 folders and 2 files
             assert sum(file_folder_count) == 2
 
             # testing sub-directory
-            res5 = await cli.get(os.path.join("list", "test"), headers={"Authorization": ""})
+            res5 = await cli.get(os.path.join("list", "test"))
             assert res5.status == 200
             json_text = await res5.text()
             json = decoder.decode(json_text)
@@ -595,11 +568,11 @@ async def test_list():
 
             # testing list dot-files
             fs.make_file(
-                os.path.join(username, "test", ".test_file_1"),  # NOSONAR python:S1192
+                os.path.join(TEST_USER, "test", ".test_file_1"),  # NOSONAR python:S1192
                 txt,
             )
             # f5 = fs.make_file(os.path.join(username, 'test', '.globus_id'), txt)
-            res6 = await cli.get("/list/", headers={"Authorization": ""})
+            res6 = await cli.get("/list/")
             assert res6.status == 200
             json_text = await res6.text()
             json = decoder.decode(json_text)
@@ -610,9 +583,7 @@ async def test_list():
             assert len(file_names) == 2
 
             # testing list showHidden option
-            res7 = await cli.get(
-                "/list/", headers={"Authorization": ""}, params={"showHidden": "True"}
-            )
+            res7 = await cli.get("/list/", params={"showHidden": "True"})
             assert res7.status == 200
             json_text = await res7.text()
             json = decoder.decode(json_text)
@@ -626,15 +597,13 @@ async def test_list():
 @settings(deadline=None)
 @asyncgiven(txt=st.text())
 async def test_download(txt):
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
 
             res = await cli.get(
                 os.path.join("download", "test", "test_file_1"),
-                headers={"Authorization": ""},
             )
             assert res.status == 200
             result_text = await res.read()
@@ -642,36 +611,36 @@ async def test_download(txt):
 
 
 async def test_download_errors():
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
+            fs.make_dir(os.path.join(TEST_USER, "test"))
 
-            res1 = await cli.get("dwnload", headers={"Authorization": ""})
+            res1 = await cli.get(
+                "dwnload",
+            )
             assert res1.status == 404
             res2 = await cli.get(
-                os.path.join("download", "test", ""), headers={"Authorization": ""}
+                os.path.join("download", "test", ""),
             )
             assert res2.status == 400
 
 
 async def test_similar():
     txt = "testing text"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1.fq"), txt)
-            fs.make_dir(os.path.join(username, "test", "test_sub_dir"))
-            fs.make_file(os.path.join(username, "test", "test_sub_dir", "test_file_2.fq"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1.fq"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test", "test_sub_dir"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_sub_dir", "test_file_2.fq"), txt)
             fs.make_file(
-                os.path.join(username, "test", "test_sub_dir", "test_file_right.fq"),
+                os.path.join(TEST_USER, "test", "test_sub_dir", "test_file_right.fq"),
                 txt,
             )
-            fs.make_file(os.path.join(username, "test", "test_sub_dir", "my_files"), txt)
+            fs.make_file(os.path.join(TEST_USER, "test", "test_sub_dir", "my_files"), txt)
 
             # testing similar file name
-            res1 = await cli.get("similar/test/test_file_1.fq", headers={"Authorization": ""})
+            res1 = await cli.get("similar/test/test_file_1.fq")
             assert res1.status == 200
             json_text = await res1.text()
             json = decoder.decode(json_text)
@@ -680,32 +649,31 @@ async def test_similar():
             assert json[1].get("name") in ["test_file_2.fq", "test_file_right.fq"]
 
             # testing non-existing file
-            res2 = await cli.get("similar/test/non-existing", headers={"Authorization": ""})
+            res2 = await cli.get("similar/test/non-existing")
             assert res2.status == 404
 
             # testing path is a directory
-            res3 = await cli.get("similar/test", headers={"Authorization": ""})
+            res3 = await cli.get("similar/test")
             assert res3.status == 400
 
 
 async def test_existence():
     txt = "testing text"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
-            fs.make_dir(os.path.join(username, "test", "test_sub_dir"))
-            fs.make_file(os.path.join(username, "test", "test_sub_dir", "test_file_2"), txt)
-            fs.make_dir(os.path.join(username, "test", "test_sub_dir", "test_file_1"))
-            fs.make_dir(os.path.join(username, "test", "test_sub_dir", "test_sub_dir"))
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test", "test_sub_dir"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test_sub_dir", "test_file_2"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test", "test_sub_dir", "test_file_1"))
+            fs.make_dir(os.path.join(TEST_USER, "test", "test_sub_dir", "test_sub_dir"))
             fs.make_file(
-                os.path.join(username, "test", "test_sub_dir", "test_sub_dir", "test_file_1"),
+                os.path.join(TEST_USER, "test", "test_sub_dir", "test_sub_dir", "test_file_1"),
                 txt,
             )
 
             # testing existence of both file and folder name
-            res1 = await cli.get("existence/test_file_1", headers={"Authorization": ""})
+            res1 = await cli.get("existence/test_file_1")
             assert res1.status == 200
             json_text = await res1.text()
             json = decoder.decode(json_text)
@@ -713,7 +681,7 @@ async def test_existence():
             assert json["isFolder"] is False
 
             # testing existence of file
-            res2 = await cli.get("existence/test_file_2", headers={"Authorization": ""})
+            res2 = await cli.get("existence/test_file_2")
             assert res2.status == 200
             json_text = await res2.text()
             json = decoder.decode(json_text)
@@ -721,7 +689,7 @@ async def test_existence():
             assert json["isFolder"] is False
 
             # testing existence of folder
-            res3 = await cli.get("existence/test_sub_dir", headers={"Authorization": ""})
+            res3 = await cli.get("existence/test_sub_dir")
             assert res3.status == 200
             json_text = await res3.text()
             json = decoder.decode(json_text)
@@ -729,14 +697,14 @@ async def test_existence():
             assert json["isFolder"] is True
 
             # testing non-existence
-            res4 = await cli.get("existence/fake_file", headers={"Authorization": ""})
+            res4 = await cli.get("existence/fake_file")
             assert res4.status == 200
             json_text = await res4.text()
             json = decoder.decode(json_text)
             assert json["exists"] is False
             assert json["isFolder"] is False
 
-            res5 = await cli.get("existence/test_sub", headers={"Authorization": ""})
+            res5 = await cli.get("existence/test_sub")
             assert res5.status == 200
             json_text = await res5.text()
             json = decoder.decode(json_text)
@@ -746,24 +714,23 @@ async def test_existence():
 
 async def test_search():
     txt = "testing text"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            fs.make_file(os.path.join(username, "test", "test1"), txt)
-            fs.make_dir(os.path.join(username, "test", "test2"))
-            fs.make_file(os.path.join(username, "test", "test2", "test3"), txt)
-            res1 = await cli.get("search/", headers={"Authorization": ""})
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test", "test2"))
+            fs.make_file(os.path.join(TEST_USER, "test", "test2", "test3"), txt)
+            res1 = await cli.get("search/")
             assert res1.status == 200
             json_text = await res1.text()
             json = decoder.decode(json_text)
             assert len(json) == 4
-            res2 = await cli.get("search/test1", headers={"Authorization": ""})
+            res2 = await cli.get("search/test1")
             assert res2.status == 200
             json_text = await res2.text()
             json = decoder.decode(json_text)
             assert len(json) == 1
-            res3 = await cli.get("search/test2", headers={"Authorization": ""})
+            res3 = await cli.get("search/test2")
             assert res3.status == 200
             json_text = await res3.text()
             json = decoder.decode(json_text)
@@ -772,19 +739,18 @@ async def test_search():
 
 async def test_upload():
     txt = "testing text\n"
-    username = "testuser"
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         # testing missing body
-        res1 = await cli.post("upload", headers={"Authorization": ""})
+        res1 = await cli.post("upload")
         assert res1.status == 400
 
         with FileUtil() as fs:
-            fs.make_dir(os.path.join(username, "test"))
-            f = fs.make_file(os.path.join(username, "test", "test_file_1"), txt)
+            fs.make_dir(os.path.join(TEST_USER, "test"))
+            f = fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
 
             files = {"destPath": "/", "uploads": open(f, "rb")}
 
-            res2 = await cli.post(os.path.join("upload"), headers={"Authorization": ""}, data=files)
+            res2 = await cli.post(os.path.join("upload"), data=files)
 
             assert res2.status == 200
 
@@ -792,12 +758,14 @@ async def test_upload():
 async def _upload_file_fail_filename(filename: str, err: str):
     # Note two file uploads in a row causes a test error:
     # https://github.com/aio-libs/aiohttp/issues/3968
-    async with await AppClient.create(config, "fake") as cli:  # username is ignored by AppClient
+    async with await AppClient.create(
+        config, TEST_TOKEN
+    ) as cli:  # username is ignored by AppClient
         formdata = FormData()
         formdata.add_field("destPath", "/")
         formdata.add_field("uploads", BytesIO(b"sometext"), filename=filename)
 
-        res = await cli.post("upload", headers={"Authorization": ""}, data=formdata)
+        res = await cli.post("upload", data=formdata)
 
         assert await res.text() == err
         assert res.status == 403
@@ -825,9 +793,8 @@ async def test_upload_fail_comma_in_file():
 async def test_directory_decompression(contents):
     fname = "test"
     dirname = "dirname"
-    username = "testuser"
-    path = utils.Path.validate_path(username, os.path.join(dirname, fname))
-    path2 = utils.Path.validate_path(username, os.path.join(dirname, fname))
+    path = utils.Path.validate_path(TEST_USER, os.path.join(dirname, fname))
+    path2 = utils.Path.validate_path(TEST_USER, os.path.join(dirname, fname))
     if path.user_path.endswith("/") or path2.user_path.endswith("/"):
         # invalid test case
         # TODO it should be faster if hypothesis could generate all cases except these
@@ -841,12 +808,12 @@ async def test_directory_decompression(contents):
         ("bztar", ".tar.bz"),
         ("tar", ".tar"),
     ]
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         for method, extension in methods:
             with FileUtil() as fs:
-                d = fs.make_dir(os.path.join(username, dirname))
+                d = fs.make_dir(os.path.join(TEST_USER, dirname))
                 f1 = fs.make_file(path.user_path, contents)
-                d2 = fs.make_dir(os.path.join(username, dirname, dirname))
+                d2 = fs.make_dir(os.path.join(TEST_USER, dirname, dirname))
                 f3 = fs.make_file(path2.user_path, contents)
                 # end common test code
                 compressed = shutil.make_archive(d, method, d[: -len(dirname)], dirname)
@@ -866,7 +833,7 @@ async def test_directory_decompression(contents):
                 assert not os.path.exists(d2)
                 assert not os.path.exists(f3)
                 assert os.path.exists(compressed)
-                resp = await cli.patch("/decompress/" + name, headers={"Authorization": ""})
+                resp = await cli.patch("/decompress/" + name)
                 assert resp.status == 200
                 text = await resp.text()
                 assert "successfully decompressed" in text
@@ -885,18 +852,17 @@ async def test_directory_decompression(contents):
 async def test_file_decompression(contents):
     fname = "test"
     dirname = "dirname"
-    username = "testuser"
-    path = utils.Path.validate_path(username, os.path.join(dirname, fname))
+    path = utils.Path.validate_path(TEST_USER, os.path.join(dirname, fname))
     if path.user_path.endswith("/"):
         # invalid test case
         # TODO it should be faster if hypothesis could generate all cases except these
         return
     methods = [("gzip", ".gz"), ("bzip2", ".bz2")]
 
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         for method, extension in methods:
             with FileUtil() as fs:
-                d = fs.make_dir(os.path.join(username, dirname))
+                d = fs.make_dir(os.path.join(TEST_USER, dirname))
                 f1 = fs.make_file(path.user_path, contents)
                 name = fname + extension
                 await utils.run_command(method, f1)
@@ -906,7 +872,6 @@ async def test_file_decompression(contents):
                 assert os.path.exists(os.path.join(d, name))
                 resp = await cli.patch(
                     "/decompress/" + os.path.join(dirname, name),
-                    headers={"Authorization": ""},
                 )
                 assert resp.status == 200
                 text = await resp.text()
@@ -922,13 +887,11 @@ async def test_importer_mappings():
     This tests calling with simple good cases, and some expected bad cases
     :return:
     """
-    username = "testuser"
-
     # Normal case, no match
     data = {"file_list": ["file1.txt"]}
     qs1 = urlencode(data, doseq=True)
 
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.get(f"importer_mappings/?{qs1}")
         assert resp.status == 200
         text = await resp.json()
@@ -940,7 +903,7 @@ async def test_importer_mappings():
     data = {"file_list": ["file1.txt", "file.tar.gz"]}
     qs2 = urlencode(data, doseq=True)
 
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.get(f"importer_mappings/?{qs2}", data=data)
         assert resp.status == 200
         text = await resp.json()
@@ -956,7 +919,7 @@ async def test_importer_mappings():
     # A dict is passed in
     data = {"file_list": [{}]}
     qs3 = urlencode(data, doseq=True)
-    async with await AppClient.create(config, username) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.get(f"importer_mappings/?{qs3}", data=data)
         assert resp.status == 200
         text = await resp.json()
@@ -974,7 +937,7 @@ async def test_importer_mappings():
 
     for data in bad_data:
         qsd = urlencode(data, doseq=True)
-        async with await AppClient.create(config, username) as cli:
+        async with await AppClient.create(config, TEST_TOKEN) as cli:
             resp = await cli.get(f"importer_mappings/?{qsd}")
             assert resp.status == 400
             text = await resp.text()
@@ -983,10 +946,10 @@ async def test_importer_mappings():
 
 async def test_bulk_specification_success():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser/somefolder")  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser"
+            fu.make_dir(f"{TEST_USER}/somefolder")
+            base = Path(fu.base_dir) / TEST_USER
             tsv = "genomes.tsv"
             with open(base / tsv, "w", encoding="utf-8") as f:
                 f.writelines(
@@ -1052,14 +1015,14 @@ async def test_bulk_specification_success():
                     "tree_sloths": [{"entity_id": "That which ends all", "preferred_food": "ꔆ"}],
                 },
                 "files": {
-                    "genomes": {"file": "testuser/genomes.tsv", "tab": None},
+                    "genomes": {"file": f"{TEST_USER}/genomes.tsv", "tab": None},
                     "breakfastcereals": {
-                        "file": "testuser/somefolder/breakfastcereals.csv",
+                        "file": f"{TEST_USER}/somefolder/breakfastcereals.csv",
                         "tab": None,
                     },
-                    "fruit_bats": {"file": "testuser/importspec.xlsx", "tab": "bats"},
+                    "fruit_bats": {"file": f"{TEST_USER}/importspec.xlsx", "tab": "bats"},
                     "tree_sloths": {
-                        "file": "testuser/importspec.xlsx",
+                        "file": f"{TEST_USER}/importspec.xlsx",
                         "tab": "sloths",
                     },
                 },
@@ -1068,12 +1031,12 @@ async def test_bulk_specification_success():
 
 
 async def test_bulk_specification_dts_success():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
-            dts_dir = f"testuser/{sub_dir}"
-            fu.make_dir(dts_dir)  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser" / sub_dir
+            dts_dir = f"{TEST_USER}/{sub_dir}"
+            fu.make_dir(dts_dir)
+            base = Path(fu.base_dir) / TEST_USER / sub_dir
             manifest_1 = "test_manifest_1.json"
             manifest_1_dict = {
                 "resources": [],
@@ -1152,20 +1115,20 @@ async def test_bulk_specification_dts_success():
                     ],
                 },
                 "files": {
-                    "gff_metagenome": {"file": f"testuser/{sub_dir}/{manifest_1}", "tab": None},
-                    "gff_genome": {"file": f"testuser/{sub_dir}/{manifest_2}", "tab": None},
+                    "gff_metagenome": {"file": f"{TEST_USER}/{sub_dir}/{manifest_1}", "tab": None},
+                    "gff_genome": {"file": f"{TEST_USER}/{sub_dir}/{manifest_2}", "tab": None},
                 },
             }
             assert resp.status == 200
 
 
 async def test_bulk_specification_dts_fail_json_without_dts():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
-            dts_dir = f"testuser/{sub_dir}"
-            fu.make_dir(dts_dir)  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser" / sub_dir
+            dts_dir = f"{TEST_USER}/{sub_dir}"
+            fu.make_dir(dts_dir)
+            base = Path(fu.base_dir) / TEST_USER / sub_dir
             manifest_1 = "test_manifest_1.json"
             manifest_1_dict = {
                 "resources": [],
@@ -1201,12 +1164,12 @@ async def test_bulk_specification_dts_fail_json_without_dts():
 
 
 async def test_bulk_specification_dts_fail_wrong_format():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
-            dts_dir = f"testuser/{sub_dir}"
-            fu.make_dir(dts_dir)  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser" / sub_dir
+            dts_dir = f"{TEST_USER}/{sub_dir}"
+            fu.make_dir(dts_dir)
+            base = Path(fu.base_dir) / TEST_USER / sub_dir
             manifest = "test_manifest.json"
             manifest_data = ["wrong", "format"]
             with open(base / manifest, "w", encoding="utf-8") as f:
@@ -1236,12 +1199,12 @@ async def test_bulk_specification_dts_fail_wrong_format():
     ],
 )
 async def test_bulk_specification_dts_fail_wrong_extension(manifest: str, expected: str):
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
-            dts_dir = f"testuser/{sub_dir}"
-            fu.make_dir(dts_dir)  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser" / sub_dir
+            dts_dir = f"{TEST_USER}/{sub_dir}"
+            fu.make_dir(dts_dir)
+            base = Path(fu.base_dir) / TEST_USER / sub_dir
             manifest_data = {"resources": [], "instructions": {}}
             with open(base / manifest, "w", encoding="utf-8") as f:
                 json.dump(manifest_data, f)
@@ -1309,7 +1272,7 @@ def test_load_and_validate_schema_bad(tmp_path: Path):
 
 
 async def test_bulk_specification_fail_no_files():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         for f in ["", "?files=", "?files=  ,   ,,   ,  "]:
             resp = await cli.get(f"bulk_specification/{f}")
             jsn = await resp.json()
@@ -1318,10 +1281,10 @@ async def test_bulk_specification_fail_no_files():
 
 
 async def test_bulk_specification_fail_not_found():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser/otherfolder")  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser"
+            fu.make_dir(f"{TEST_USER}/otherfolder")
+            base = Path(fu.base_dir) / TEST_USER
             tsv = "otherfolder/genomes.tsv"
             with open(base / tsv, "w", encoding="utf-8") as f:
                 f.writelines(
@@ -1335,7 +1298,7 @@ async def test_bulk_specification_fail_not_found():
             resp = await cli.get(f"bulk_specification/?files={tsv},somefile.csv")
             jsn = await resp.json()
             assert jsn == {
-                "errors": [{"type": "cannot_find_file", "file": "testuser/somefile.csv"}]
+                "errors": [{"type": "cannot_find_file", "file": f"{TEST_USER}/somefile.csv"}]
             }
             assert resp.status == 404
 
@@ -1345,10 +1308,10 @@ async def test_bulk_specification_fail_parse_fail():
     Tests a number of different parse fail cases, including incorrect file types.
     Also tests that all the errors are combined correctly.
     """
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser/otherfolder")  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser"
+            fu.make_dir(f"{TEST_USER}/otherfolder")
+            base = Path(fu.base_dir) / TEST_USER
             tsv = "otherfolder/genomes.tsv"
             # this one is fine
             with open(base / tsv, "w", encoding="utf-8") as f:
@@ -1409,43 +1372,43 @@ async def test_bulk_specification_fail_parse_fail():
                         "message": 'Invalid header; got "Dater type: breakfastcereals; '
                         + 'Columns: 3; Version: 1", expected "Data type: <data_type>; '
                         + 'Columns: <column count>; Version: <version>"',
-                        "file": "testuser/otherfolder/thing.csv",
+                        "file": f"{TEST_USER}/otherfolder/thing.csv",
                         "tab": None,
                     },
                     {
                         "type": "cannot_parse_file",
                         "message": "Missing header entry in row 2, position 1",
-                        "file": "testuser/stuff.xlsx",
+                        "file": f"{TEST_USER}/stuff.xlsx",
                         "tab": "sloths",
                     },
                     {
                         "type": "cannot_parse_file",
                         "message": "badfile is not a supported file type for import specifications",
-                        "file": "testuser/badfile",
+                        "file": f"{TEST_USER}/badfile",
                         "tab": None,
                     },
                     {
                         "type": "cannot_parse_file",
                         "message": "fasta.gz is not a supported file type for import specifications",
-                        "file": "testuser/badfile.fasta.gz",
+                        "file": f"{TEST_USER}/badfile.fasta.gz",
                         "tab": None,
                     },
                     {
                         "type": "cannot_parse_file",
                         "message": "sra is not a supported file type for import specifications",
-                        "file": "testuser/badfile.sra",
+                        "file": f"{TEST_USER}/badfile.sra",
                         "tab": None,
                     },
                     {
                         "type": "cannot_parse_file",
                         "message": "sys is not a supported file type for import specifications",
-                        "file": "testuser/badfile.sys",
+                        "file": f"{TEST_USER}/badfile.sys",
                         "tab": None,
                     },
                     {
                         "type": "cannot_parse_file",
                         "message": "badfile. is not a supported file type for import specifications",
-                        "file": "testuser/badfile.",
+                        "file": f"{TEST_USER}/badfile.",
                         "tab": None,
                     },
                 ]
@@ -1454,10 +1417,10 @@ async def test_bulk_specification_fail_parse_fail():
 
 
 async def test_bulk_specification_fail_column_count():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser")  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser"
+            fu.make_dir(TEST_USER)
+            base = Path(fu.base_dir) / TEST_USER
             tsv = "genomes.tsv"
             # this one is fine
             with open(base / tsv, "w", encoding="utf-8") as f:
@@ -1512,13 +1475,13 @@ async def test_bulk_specification_fail_column_count():
                     {
                         "type": "incorrect_column_count",
                         "message": "Incorrect number of items in line 4, expected 3, got 2",
-                        "file": "testuser/thing.csv",
+                        "file": f"{TEST_USER}/thing.csv",
                         "tab": None,
                     },
                     {
                         "type": "incorrect_column_count",
                         "message": "Incorrect number of items in line 4, expected 2, got 3",
-                        "file": "testuser/stuff.xlsx",
+                        "file": f"{TEST_USER}/stuff.xlsx",
                         "tab": "bats",
                     },
                 ]
@@ -1527,10 +1490,10 @@ async def test_bulk_specification_fail_column_count():
 
 
 async def test_bulk_specification_fail_multiple_specs_per_type():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser")  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser"
+            fu.make_dir(TEST_USER)
+            base = Path(fu.base_dir) / TEST_USER
             tsv = "genomes.tsv"
             # this one is fine
             with open(base / tsv, "w", encoding="utf-8") as f:
@@ -1597,17 +1560,17 @@ async def test_bulk_specification_fail_multiple_specs_per_type():
                     {
                         "type": "multiple_specifications_for_data_type",
                         "message": err,
-                        "file_1": "testuser/thing.csv",
+                        "file_1": f"{TEST_USER}/thing.csv",
                         "tab_1": None,
-                        "file_2": "testuser/thing2.csv",
+                        "file_2": f"{TEST_USER}/thing2.csv",
                         "tab_2": None,
                     },
                     {
                         "type": "multiple_specifications_for_data_type",
                         "message": err,
-                        "file_1": "testuser/thing.csv",
+                        "file_1": f"{TEST_USER}/thing.csv",
                         "tab_1": None,
-                        "file_2": "testuser/stuff.xlsx",
+                        "file_2": f"{TEST_USER}/stuff.xlsx",
                         "tab_2": "bats",
                     },
                 ]
@@ -1620,10 +1583,10 @@ async def test_bulk_specification_fail_multiple_specs_per_type_excel():
     Test an excel file with an internal data type collision.
     This is the only case when all 5 error fields are filled out.
     """
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser")  # testuser is hardcoded in the auth mock
-            base = Path(fu.base_dir) / "testuser"
+            fu.make_dir(TEST_USER)
+            base = Path(fu.base_dir) / TEST_USER
             excel = "stuff.xlsx"
             # https://github.com/PyCQA/pylint/issues/3060
             # pylint: disable=abstract-class-instantiated
@@ -1663,9 +1626,9 @@ async def test_bulk_specification_fail_multiple_specs_per_type_excel():
                     {
                         "type": "multiple_specifications_for_data_type",
                         "message": "Found datatype breakfastcereals in multiple tabs",
-                        "file_1": "testuser/stuff.xlsx",
+                        "file_1": f"{TEST_USER}/stuff.xlsx",
                         "tab_1": "bats",
-                        "file_2": "testuser/stuff.xlsx",
+                        "file_2": f"{TEST_USER}/stuff.xlsx",
                         "tab_2": "otherbats",
                     },
                 ]
@@ -1695,9 +1658,9 @@ _IMPORT_SPEC_TEST_DATA = {
 
 async def test_write_bulk_specification_success_csv():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser")  # testuser is hardcoded in the auth mock
+            fu.make_dir(TEST_USER)
             resp = await cli.post(
                 "write_bulk_specification/",  # NOSONAR
                 json={
@@ -1710,11 +1673,11 @@ async def test_write_bulk_specification_success_csv():
             assert js == {
                 "output_file_type": "CSV",
                 "files_created": {
-                    "genome": "testuser/specs/genome.csv",
-                    "reads": "testuser/specs/reads.csv",
+                    "genome": f"{TEST_USER}/specs/genome.csv",
+                    "reads": f"{TEST_USER}/specs/reads.csv",
                 },
             }
-            base = Path(fu.base_dir) / "testuser"
+            base = Path(fu.base_dir) / TEST_USER
             check_file_contents(
                 base / "specs/genome.csv",
                 [
@@ -1738,9 +1701,9 @@ async def test_write_bulk_specification_success_csv():
 
 async def test_write_bulk_specification_success_tsv():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser")  # testuser is hardcoded in the auth mock
+            fu.make_dir(TEST_USER)
             types = dict(_IMPORT_SPEC_TEST_DATA)
             types["reads"] = dict(types["reads"])
             types["reads"]["data"] = []
@@ -1756,11 +1719,11 @@ async def test_write_bulk_specification_success_tsv():
             assert js == {
                 "output_file_type": "TSV",
                 "files_created": {
-                    "genome": "testuser/tsvspecs/genome.tsv",
-                    "reads": "testuser/tsvspecs/reads.tsv",
+                    "genome": f"{TEST_USER}/tsvspecs/genome.tsv",
+                    "reads": f"{TEST_USER}/tsvspecs/reads.tsv",
                 },
             }
-            base = Path(fu.base_dir) / "testuser"
+            base = Path(fu.base_dir) / TEST_USER
             check_file_contents(
                 base / "tsvspecs/genome.tsv",
                 [
@@ -1783,9 +1746,9 @@ async def test_write_bulk_specification_success_tsv():
 
 async def test_write_bulk_specification_success_excel():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         with FileUtil() as fu:
-            fu.make_dir("testuser")  # testuser is hardcoded in the auth mock
+            fu.make_dir(TEST_USER)
             resp = await cli.post(
                 "write_bulk_specification/",
                 json={
@@ -1798,11 +1761,11 @@ async def test_write_bulk_specification_success_excel():
             assert js == {
                 "output_file_type": "EXCEL",
                 "files_created": {
-                    "genome": "testuser/import_specification.xlsx",
-                    "reads": "testuser/import_specification.xlsx",
+                    "genome": f"{TEST_USER}/import_specification.xlsx",
+                    "reads": f"{TEST_USER}/import_specification.xlsx",
                 },
             }
-            wb = openpyxl.load_workbook(Path(fu.base_dir) / "testuser/import_specification.xlsx")
+            wb = openpyxl.load_workbook(Path(fu.base_dir) / TEST_USER / "import_specification.xlsx")
             assert wb.sheetnames == ["genome", "reads"]
             check_excel_contents(
                 wb,
@@ -1830,7 +1793,7 @@ async def test_write_bulk_specification_success_excel():
 
 
 async def test_write_bulk_specification_fail_wrong_data_type():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.post("write_bulk_specification/", data="foo")
         js = await resp.json()
         assert js == {"error": "Required content-type is application/json"}
@@ -1838,7 +1801,7 @@ async def test_write_bulk_specification_fail_wrong_data_type():
 
 
 async def test_write_bulk_specification_fail_no_content_length():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.post(
             "write_bulk_specification", headers={"content-type": "application/json"}
         )
@@ -1848,7 +1811,7 @@ async def test_write_bulk_specification_fail_no_content_length():
 
 
 async def test_write_bulk_specification_fail_large_input():
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.post("write_bulk_specification/", json="a" * (1024 * 1024 - 2))
         txt = await resp.text()
         # this seems to be a built in (somewhat inaccurate) server feature
@@ -1857,7 +1820,7 @@ async def test_write_bulk_specification_fail_large_input():
 
 
 async def _write_bulk_specification_json_fail(json: Any, err: str):
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.post("write_bulk_specification", json=json)
         js = await resp.json()
         assert js == {"error": err}
@@ -1906,7 +1869,7 @@ async def test_importer_filetypes():
     """
     Only checks a few example entries since the list may expand over time
     """
-    async with await AppClient.create(config) as cli:
+    async with await AppClient.create(config, TEST_TOKEN) as cli:
         resp = await cli.get("importer_filetypes")
         js = await resp.json()
         assert set(js.keys()) == {"datatype_to_filetype", "filetype_to_extensions"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,7 +67,7 @@ def asyncgiven(**kwargs):
     return real_decorator
 
 
-async def mock_globus_app(config: configparser.ConfigParser, mock_username: str):
+async def mock_globus_app(config: configparser.ConfigParser):
     application = await app.app_factory(config)
 
     async def mock_globus_id(*args, **kwargs):
@@ -91,7 +91,7 @@ class AppClient:
         If you want to make a call with a different header, you can
         do so by setting headers directly in the call.
         """
-        app = await mock_globus_app(config, auth_token)
+        app = await mock_globus_app(config)
         server = test_utils.TestServer(app)
         return AppClient(server, auth_token, cookies)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -213,47 +213,37 @@ async def test_cmd(txt):
         assert md5 == expected_md5
 
 
-async def test_auth():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+async def do_auth_test(
+    token: str, cookies: dict[str, str] | None, expected_status: int, expected_text: str
+):
+    async with await AppClient.create(config, token, cookies=cookies) as cli:
         resp = await cli.get("/test-auth")
-        assert resp.status == 200
+        assert resp.status == expected_status
         text = await resp.text()
-        assert f"I'm authenticated as {TEST_USER}" in text
+        assert expected_text in text
+
+
+async def test_auth():
+    await do_auth_test(TEST_TOKEN, None, 200, f"I'm authenticated as {TEST_USER}")
 
 
 @pytest.mark.parametrize("cookie_name", ["kbase_session", "kbase_session_backup"])
 async def test_auth_cookies(cookie_name):
-    async with await AppClient.create(config, None, cookies={cookie_name: TEST_TOKEN}) as cli:
-        resp = await cli.get("/test-auth")
-        assert resp.status == 200
-        text = await resp.text()
-        assert f"I'm authenticated as {TEST_USER}" in text
+    await do_auth_test(None, {cookie_name: TEST_TOKEN}, 200, f"I'm authenticated as {TEST_USER}")
 
 
 @pytest.mark.parametrize("token", [None, ""])
 async def test_auth_fail_no_token(token):
-    async with await AppClient.create(config, token) as cli:
-        resp = await cli.get("/test-auth")
-        assert resp.status == 401
-        text = await resp.text()
-        assert "must provide an auth token" in text
+    await do_auth_test(token, None, 401, "must provide an auth token")
 
 
 async def test_auth_fail_bad_token():
-    async with await AppClient.create(config, "bad token") as cli:
-        resp = await cli.get("/test-auth")
-        assert resp.status == 401
-        text = await resp.text()
-        assert "token is invalid" in text
+    await do_auth_test("bad_token", None, 401, "token is invalid")
 
 
 @pytest.mark.parametrize("cookie_name", ["kbase_session", "kbase_session_backup"])
 async def test_auth_fail_bad_cookie_token(cookie_name):
-    async with await AppClient.create(config, None, cookies={cookie_name: "bad_token"}) as cli:
-        resp = await cli.get("/test-auth")
-        assert resp.status == 401
-        text = await resp.text()
-        assert "token is invalid" in text
+    await do_auth_test(None, {cookie_name: "bad_token"}, 401, "token is invalid")
 
 
 async def test_auth_fail_service_err():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -214,7 +214,7 @@ async def test_cmd(txt):
 
 
 async def do_auth_test(
-    token: str, cookies: dict[str, str] | None, expected_status: int, expected_text: str
+    token: str | None, cookies: dict[str, str] | None, expected_status: int, expected_text: str
 ):
     async with await AppClient.create(config, token, cookies=cookies) as cli:
         resp = await cli.get("/test-auth")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -79,7 +79,12 @@ async def mock_globus_app(config: configparser.ConfigParser, mock_username: str)
 
 class AppClient:
     @classmethod
-    async def create(cls, config: configparser.ConfigParser, auth_token: str | None, cookies: dict[str, str] | None = None) -> "AppClient":
+    async def create(
+        cls,
+        config: configparser.ConfigParser,
+        auth_token: str | None,
+        cookies: dict[str, str] | None = None,
+    ) -> "AppClient":
         """
         Creating this with an auth token sets the headers call by default to use the
         provided auth token in the Authorization header.
@@ -90,7 +95,9 @@ class AppClient:
         server = test_utils.TestServer(app)
         return AppClient(server, auth_token, cookies)
 
-    def __init__(self, server: test_utils.TestServer, auth_token: str | None, cookies: dict[str, str] | None):
+    def __init__(
+        self, server: test_utils.TestServer, auth_token: str | None, cookies: dict[str, str] | None
+    ):
         self.server = server
         self.auth_token = auth_token
         self.cookies = cookies
@@ -212,6 +219,7 @@ async def test_auth():
         assert resp.status == 200
         text = await resp.text()
         assert f"I'm authenticated as {TEST_USER}" in text
+
 
 @pytest.mark.parametrize("cookie_name", ["kbase_session", "kbase_session_backup"])
 async def test_auth_cookies(cookie_name):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -79,7 +79,7 @@ async def mock_globus_app(config: configparser.ConfigParser, mock_username: str)
 
 class AppClient:
     @classmethod
-    async def create(cls, config: configparser.ConfigParser, auth_token: str | None) -> "AppClient":
+    async def create(cls, config: configparser.ConfigParser, auth_token: str | None, cookies: dict[str, str] | None = None) -> "AppClient":
         """
         Creating this with an auth token sets the headers call by default to use the
         provided auth token in the Authorization header.
@@ -88,11 +88,12 @@ class AppClient:
         """
         app = await mock_globus_app(config, auth_token)
         server = test_utils.TestServer(app)
-        return AppClient(server, auth_token)
+        return AppClient(server, auth_token, cookies)
 
-    def __init__(self, server: test_utils.TestServer, auth_token: str | None):
+    def __init__(self, server: test_utils.TestServer, auth_token: str | None, cookies: dict[str, str] | None):
         self.server = server
         self.auth_token = auth_token
+        self.cookies = cookies
 
     async def __aenter__(self) -> test_utils.TestClient:
         await self.server.start_server(loop=asyncio.get_event_loop())
@@ -100,7 +101,7 @@ class AppClient:
         if self.auth_token is not None:
             headers["Authorization"] = self.auth_token
         self.client = test_utils.TestClient(
-            self.server, loop=asyncio.get_event_loop(), headers=headers
+            self.server, loop=asyncio.get_event_loop(), headers=headers, cookies=self.cookies
         )
         return self.client
 
@@ -211,6 +212,46 @@ async def test_auth():
         assert resp.status == 200
         text = await resp.text()
         assert f"I'm authenticated as {TEST_USER}" in text
+
+@pytest.mark.parametrize("cookie_name", ["kbase_session", "kbase_session_backup"])
+async def test_auth_cookies(cookie_name):
+    async with await AppClient.create(config, None, cookies={cookie_name: TEST_TOKEN}) as cli:
+        resp = await cli.get("/test-auth")
+        assert resp.status == 200
+        text = await resp.text()
+        assert f"I'm authenticated as {TEST_USER}" in text
+
+
+@pytest.mark.parametrize("token", [None, ""])
+async def test_auth_fail_no_token(token):
+    async with await AppClient.create(config, token) as cli:
+        resp = await cli.get("/test-auth")
+        assert resp.status == 401
+        text = await resp.text()
+        assert "must provide an auth token" in text
+
+
+async def test_auth_fail_bad_token():
+    async with await AppClient.create(config, "bad token") as cli:
+        resp = await cli.get("/test-auth")
+        assert resp.status == 401
+        text = await resp.text()
+        assert "token is invalid" in text
+
+
+@pytest.mark.parametrize("cookie_name", ["kbase_session", "kbase_session_backup"])
+async def test_auth_fail_bad_cookie_token(cookie_name):
+    async with await AppClient.create(config, None, cookies={cookie_name: "bad_token"}) as cli:
+        resp = await cli.get("/test-auth")
+        assert resp.status == 401
+        text = await resp.text()
+        assert "token is invalid" in text
+
+
+async def test_auth_fail_service_err():
+    # Not sure how to test this, as the service should fail on startup with a bad auth URL
+    # TODO: configure a local auth server with bad data to test this
+    pass
 
 
 async def test_service():


### PR DESCRIPTION
See #221 for details

Recent work updated the auth client and added a related test suite. Further updates resulted in a check in the auth client invoking code to bail out early while doing authorization if no auth token was given.

Most tests had the auth client call mocked out - but not that new step that didn't invoke the auth client - so they failed a lot.
(see this thread for more discussion: https://github.com/kbase/staging_service/pull/218#discussion_r2178162089)

This fixes that by doing a few things.
1. Add the pre-auth-client check for an auth token. If no token, don't call the auth client, and just throw a 401 Unauthorized.
2. Update the test stack to make use of an environment variable for a token for use with CI.
3. Remove the auth mock to let calls proceed as usual.
4. Remove the custom headers that made most tests happen without an auth token.
5. Update the README to tell the user that they'll need an auth token (and the associated username) for tests to run.

There are two possible TODOs that come up here:
1. Configure a local auth server (edit docker-compose.yml) for optional local and GHA testing.
2. Add credentials to the test config, or to `run_tests.sh` to avoid having to juggle environment variables when running locally.