### PR TITLE
CE-394 Add service token

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ to run inside docker run /run_in_docker.sh
 -  requires python 3.11.4 or higher
 -  requires installation on mac of libmagic: `brew install libmagic` or `sudo port install libmagic`.
 -  testing requires a KBase auth token (see AUTH_URL configuration in `deployment/conf/testing.cfg` 
-   for relevant KBase environment) and KBase user id. These should be in environment variables 
+   for relevant KBase environment) and KBase user id. These must be in environment variables 
    `KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
 
 ## debugging

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to run inside docker run /run_in_docker.sh
 -  to test use `./run_tests.sh`
 -  requires python 3.11.4 or higher
 -  requires installation on mac of libmagic: `brew install libmagic` or `sudo port install libmagic`.
--  testing requires a KBase CI auth token (or wherever configured in `deployment/conf/testing.cfg`) and KBase user id. These should be in environment variables `KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
+-  testing requires a KBase auth token (see AUTH_URL configuration in `deployment/conf/testing.cfg` for relevant KBase environemnt) and KBase user id. These should be in environment variables `KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
 
 ## debugging
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ to run inside docker run /run_in_docker.sh
 -  requires python 3.11.4 or higher
 -  requires installation on mac of libmagic: `brew install libmagic` or `sudo port install libmagic`.
 -  testing requires a KBase auth token (see AUTH_URL configuration in `deployment/conf/testing.cfg` 
-for relevant KBase environment) and KBase user id. These should be in environment variables 
-`KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
+   for relevant KBase environment) and KBase user id. These should be in environment variables 
+   `KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
 
 ## debugging
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ to run inside docker run /run_in_docker.sh
 -  to test use `./run_tests.sh`
 -  requires python 3.11.4 or higher
 -  requires installation on mac of libmagic: `brew install libmagic` or `sudo port install libmagic`.
--  testing requires a KBase auth token (see AUTH_URL configuration in `deployment/conf/testing.cfg` for relevant KBase environemnt) and KBase user id. These should be in environment variables `KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
+-  testing requires a KBase auth token (see AUTH_URL configuration in `deployment/conf/testing.cfg` 
+for relevant KBase environment) and KBase user id. These should be in environment variables 
+`KBASE_TEST_TOKEN` and `KBASE_TEST_USER`, respectively.
 
 ## debugging
 

--- a/deployment/conf/testing.cfg
+++ b/deployment/conf/testing.cfg
@@ -6,8 +6,3 @@ CONCIERGE_PATH = /kbaseconcierge
 FILE_EXTENSION_MAPPINGS = ./deployment/conf/supported_apps_w_extensions.json
 ;FILE_EXTENSION_MAPPINGS_PYCHARM = ../deployment/conf/supported_apps_w_extensions.json
 DTS_MANIFEST_SCHEMA = ./import_specifications/schema/dts_manifest_schema.json
-; replace with a real test auth token from the AUTH_URL environment.
-; don't check it in to github or you will be ruthlessly teased.
-TEST_TOKEN = some_test_token
-; replace with the real test username matching the test token.
-TEST_USER = kbase_user

--- a/deployment/conf/testing.cfg
+++ b/deployment/conf/testing.cfg
@@ -6,3 +6,8 @@ CONCIERGE_PATH = /kbaseconcierge
 FILE_EXTENSION_MAPPINGS = ./deployment/conf/supported_apps_w_extensions.json
 ;FILE_EXTENSION_MAPPINGS_PYCHARM = ../deployment/conf/supported_apps_w_extensions.json
 DTS_MANIFEST_SCHEMA = ./import_specifications/schema/dts_manifest_schema.json
+; replace with a real test auth token from the AUTH_URL environment.
+; don't check it in to github or you will be ruthlessly teased.
+TEST_TOKEN = some_test_token
+; replace with the real test username matching the test token.
+TEST_USER = kbase_user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # WARNING this file does not sync up with the deployment automatically
-version: "3.1"
 services:
   staging_service:
     image: kbase/staging_service:develop
@@ -10,7 +9,7 @@ services:
     volumes:
       - "./data:/kb/deployment/lib/src/data"
       - "./:/staging_service"
-
     environment:
-      - KB_DEPLOYMENT_CONFIG=/kb/deployment/conf/deployment.cfg
-      - FILE_LIFETIME="90"
+      KB_DEPLOYMENT_CONFIG: /kb/deployment/conf/deployment.cfg
+      FILE_LIFETIME: "90"
+      AUTH_TOKEN: fake_token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,5 @@ services:
     environment:
       KB_DEPLOYMENT_CONFIG: /kb/deployment/conf/deployment.cfg
       FILE_LIFETIME: "90"
+      # This is the expected service token. Modify this so it's real for the environment.
       AUTH_TOKEN: fake_token

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,6 +3,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 export KB_DEPLOYMENT_CONFIG="$DIR/deployment/conf/testing.cfg"
 export FILE_LIFETIME="90"
 export TESTS="${1:-tests}"
+export AUTH_TOKEN="fake_token"
 echo
 echo "****************************"
 echo "**"

--- a/staging_service/__main__.py
+++ b/staging_service/__main__.py
@@ -1,15 +1,19 @@
 import asyncio
-import configparser
 import os
 
 import uvloop
 from aiohttp import web
 
 from .app import app_factory
+from staging_service.config import StagingServiceConfig
+
+CONFIG_ENV = "KB_DEPLOYMENT_CONFIG"
+
+if CONFIG_ENV not in os.environ:
+    raise FileNotFoundError(f"Missing required config environment variable: {CONFIG_ENV}")
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())  # for speed of event loop
 
-config = configparser.ConfigParser()
-config.read(os.environ["KB_DEPLOYMENT_CONFIG"])
+config = StagingServiceConfig(os.environ.get("KB_DEPLOYMENT_CONFIG"))
 app = asyncio.run(app_factory(config))
 web.run_app(app, port=3000)

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from configparser import ConfigParser
 import json
 import logging
 import os
@@ -12,6 +11,8 @@ from urllib.parse import parse_qs, unquote
 import aiohttp_cors
 from aiohttp import web
 import jsonschema
+
+from staging_service.config import StagingServiceConfig
 
 from .app_error_formatter import format_import_spec_errors
 from .kb_auth_client import KBaseAuth, InvalidTokenError
@@ -637,7 +638,7 @@ def load_and_validate_schema(schema_path: PathPy) -> jsonschema.Draft202012Valid
     return jsonschema.Draft202012Validator(dts_schema)
 
 
-def inject_config_dependencies(config):
+def inject_config_dependencies(config: StagingServiceConfig):
     """
     # TODO this is pretty hacky dependency injection
     # potentially some type of code restructure would allow this without a bunch of globals
@@ -645,52 +646,17 @@ def inject_config_dependencies(config):
     :param config: The staging service main config
     """
 
-    DATA_DIR = config["staging_service"]["DATA_DIR"]
-    META_DIR = config["staging_service"]["META_DIR"]
-    CONCIERGE_PATH = config["staging_service"]["CONCIERGE_PATH"]
-    FILE_EXTENSION_MAPPINGS = config["staging_service"]["FILE_EXTENSION_MAPPINGS"]
-    DTS_MANIFEST_SCHEMA_PATH = config["staging_service"]["DTS_MANIFEST_SCHEMA"]
-
-    if DATA_DIR.startswith("."):
-        DATA_DIR = os.path.normpath(os.path.join(os.getcwd(), DATA_DIR))
-    if META_DIR.startswith("."):
-        META_DIR = os.path.normpath(os.path.join(os.getcwd(), META_DIR))
-    if CONCIERGE_PATH.startswith("."):
-        CONCIERGE_PATH = os.path.normpath(os.path.join(os.getcwd(), CONCIERGE_PATH))
-    if FILE_EXTENSION_MAPPINGS.startswith("."):
-        FILE_EXTENSION_MAPPINGS = os.path.normpath(
-            os.path.join(os.getcwd(), FILE_EXTENSION_MAPPINGS)
-        )
-    if DTS_MANIFEST_SCHEMA_PATH.startswith("."):
-        DTS_MANIFEST_SCHEMA_PATH = os.path.normpath(
-            os.path.join(os.getcwd(), DTS_MANIFEST_SCHEMA_PATH)
-        )
-
-    Path._DATA_DIR = DATA_DIR
-    Path._META_DIR = META_DIR
-    Path._CONCIERGE_PATH = CONCIERGE_PATH
-
-    if Path._DATA_DIR is None:
-        raise Exception("Please provide DATA_DIR in the config file ")
-
-    if Path._META_DIR is None:
-        raise Exception("Please provide META_DIR in the config file ")
-
-    if Path._CONCIERGE_PATH is None:
-        raise Exception("Please provide CONCIERGE_PATH in the config file ")
-
-    if DTS_MANIFEST_SCHEMA_PATH is None:
-        raise Exception("Please provide DTS_MANIFEST_SCHEMA in the config file")
+    Path._DATA_DIR = config.data_dir
+    Path._META_DIR = config.meta_dir
+    Path._CONCIERGE_PATH = config.concierge_path
 
     global _DTS_MANIFEST_VALIDATOR
     # will raise an Exception if the schema is invalid
     # TODO: write automated tests that exercise this code under different config
     # conditions and error states.
-    _DTS_MANIFEST_VALIDATOR = load_and_validate_schema(DTS_MANIFEST_SCHEMA_PATH)
+    _DTS_MANIFEST_VALIDATOR = load_and_validate_schema(config.dts_manifest_schema)
 
-    if FILE_EXTENSION_MAPPINGS is None:
-        raise Exception("Please provide FILE_EXTENSION_MAPPINGS in the config file ")
-    with open(FILE_EXTENSION_MAPPINGS, "r", encoding="utf-8") as file_extension_mappings_file:
+    with open(config.file_extension_mappings, "r", encoding="utf-8") as file_extension_mappings_file:
         AutoDetectUtils.set_mappings(json.load(file_extension_mappings_file))
         datatypes = defaultdict(set)
         extensions = defaultdict(set)
@@ -713,7 +679,7 @@ def inject_config_dependencies(config):
 auth_client = None
 
 
-async def app_factory(config: ConfigParser) -> web.Application:
+async def app_factory(config: StagingServiceConfig) -> web.Application:
     app = web.Application(middlewares=[web.normalize_path_middleware()])
     app.router.add_routes(routes)
     cors = aiohttp_cors.setup(
@@ -731,6 +697,6 @@ async def app_factory(config: ConfigParser) -> web.Application:
     inject_config_dependencies(config)
 
     global auth_client
-    auth_client = await KBaseAuth.create(config["staging_service"]["AUTH_URL"])
+    auth_client = await KBaseAuth.create(config.auth_url)
 
     return app

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -656,7 +656,9 @@ def inject_config_dependencies(config: StagingServiceConfig):
     # conditions and error states.
     _DTS_MANIFEST_VALIDATOR = load_and_validate_schema(config.dts_manifest_schema)
 
-    with open(config.file_extension_mappings, "r", encoding="utf-8") as file_extension_mappings_file:
+    with open(
+        config.file_extension_mappings, "r", encoding="utf-8"
+    ) as file_extension_mappings_file:
         AutoDetectUtils.set_mappings(json.load(file_extension_mappings_file))
         datatypes = defaultdict(set)
         extensions = defaultdict(set)

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -20,7 +20,7 @@ class StagingServiceConfig:
     This requires that all values are present.
     See deployment/conf/deployment.cfg for an example.
     It also holds the service auth token from the AUTH_TOKEN environment variable.
-    TODO: update when AUTH_TOKEN is moved into the config - see issue #227
+    TODO: update when AUTH_TOKEN is moved into the config - see issue #228
     """
 
     def __init__(self, config_path: str):

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -17,13 +17,25 @@ _TEST_USER = "TEST_USER"
 class StagingServiceConfig:
     """
     Constructs a simple config object from a passed config file path.
-    This requires that all values are present.
+    This requires that all required values are present.
     See deployment/conf/deployment.cfg for an example.
     It also holds the service auth token from the AUTH_TOKEN environment variable.
     TODO: update when AUTH_TOKEN is moved into the config - see issue #228
     """
 
     def __init__(self, config_path: str):
+        """
+        Reads the INI-formatted config file at `config_path`.
+        This expects a single section - staging_service.
+        Required keys are given above - all except _TEST_TOKEN and _TEST_USER.
+        Any required key that is missing or null will raise a ValueError.
+        Raises a ValueError if the config_path is not provided.
+        Raises a FileNotFoundError if config_path is not found.
+        Raises a MissingAuthToken error if the AUTH_TOKEN environment variable is not provided.
+        (TODO: update with issue #228)
+
+        config_path: str - the path to the INI-formatted config file
+        """
         if not config_path:
             raise ValueError("config_path is required")
 

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -11,6 +11,7 @@ _FILE_EXTENSION_MAPPINGS = "FILE_EXTENSION_MAPPINGS"
 _DTS_MANIFEST_SCHEMA = "DTS_MANIFEST_SCHEMA"
 _HEADING = "staging_service"
 
+
 class StagingServiceConfig:
     """
     Constructs a simple config object from a passed config file path.
@@ -60,6 +61,7 @@ class StagingServiceConfig:
         except ValueError as err:
             # tack the file name on the error string
             raise ValueError(f"Config file {config_path} error: " + str(err))
+
 
 def _get_value(section: SectionProxy, key: str, is_required: bool = True) -> str | None:
     """

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -73,5 +73,3 @@ def _get_path_value(section: SectionProxy, key: str) -> str:
 
 class MissingAuthToken(Exception):
     """Should be raised if the auth token environment variable is missing or empty"""
-
-    pass

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -10,7 +10,8 @@ _CONCIERGE_PATH = "CONCIERGE_PATH"
 _FILE_EXTENSION_MAPPINGS = "FILE_EXTENSION_MAPPINGS"
 _DTS_MANIFEST_SCHEMA = "DTS_MANIFEST_SCHEMA"
 _HEADING = "staging_service"
-
+_TEST_TOKEN = "TEST_TOKEN"
+_TEST_USER = "TEST_USER"
 
 class StagingServiceConfig:
     """
@@ -44,14 +45,17 @@ class StagingServiceConfig:
         self.concierge_path = _get_path_value(heading, _CONCIERGE_PATH)
         self.file_extension_mappings = _get_path_value(heading, _FILE_EXTENSION_MAPPINGS)
         self.dts_manifest_schema = _get_path_value(heading, _DTS_MANIFEST_SCHEMA)
+        self.test_token = _get_value(heading, _TEST_TOKEN, is_required=False)
+        self.test_user = _get_value(heading, _TEST_USER, is_required=False)
 
 
-def _get_value(section: SectionProxy, key: str) -> str:
+def _get_value(section: SectionProxy, key: str, is_required: bool = True) -> str | None:
     """
     Returns the value for a key in the given ConfigParser section.
-    If not present, this raises a ValueError
+    If is_required is True, and the value isn't present, this raises a ValueError.
+    If is_required is False, and the value isn't present, this returns None.
     """
-    if key not in section:
+    if key not in section and is_required:
         raise ValueError(f"Please provide {key} in the config file section {section.name}")
     return section.get(key)
 
@@ -62,8 +66,6 @@ def _get_path_value(section: SectionProxy, key: str) -> str:
     it absolute. I.e. a path like ./foo becomes /path/to/local/dir/foo
     TODO: This returns paths as strings, not Path-like objects, as much of the rest of the service
     expects them that way. Consider changing it later.
-    TODO: Consider adding path validation here for required paths (like the data directory or the
-    DTS manifest schema file)
     """
     value = _get_value(section, key)
     if value is not None and value.startswith("."):

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -10,9 +10,6 @@ _CONCIERGE_PATH = "CONCIERGE_PATH"
 _FILE_EXTENSION_MAPPINGS = "FILE_EXTENSION_MAPPINGS"
 _DTS_MANIFEST_SCHEMA = "DTS_MANIFEST_SCHEMA"
 _HEADING = "staging_service"
-_TEST_TOKEN = "TEST_TOKEN"
-_TEST_USER = "TEST_USER"
-
 
 class StagingServiceConfig:
     """
@@ -63,9 +60,6 @@ class StagingServiceConfig:
         except ValueError as err:
             # tack the file name on the error string
             raise ValueError(f"Config file {config_path} error: " + str(err))
-        self.test_token = _get_value(heading, _TEST_TOKEN, is_required=False)
-        self.test_user = _get_value(heading, _TEST_USER, is_required=False)
-
 
 def _get_value(section: SectionProxy, key: str, is_required: bool = True) -> str | None:
     """

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -13,6 +13,7 @@ _HEADING = "staging_service"
 _TEST_TOKEN = "TEST_TOKEN"
 _TEST_USER = "TEST_USER"
 
+
 class StagingServiceConfig:
     """
     Constructs a simple config object from a passed config file path.

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -1,0 +1,45 @@
+from configparser import ConfigParser, SectionProxy
+import os
+from pathlib import Path
+
+_META_DIR = "META_DIR"
+_DATA_DIR = "DATA_DIR"
+_AUTH_URL = "AUTH_URL"
+_CONCIERGE_PATH = "CONCIERGE_PATH"
+_FILE_EXTENSION_MAPPINGS = "FILE_EXTENSION_MAPPINGS"
+_DTS_MANIFEST_SCHEMA = "DTS_MANIFEST_SCHEMA"
+_HEADING = "staging_service"
+
+class StagingServiceConfig:
+    def __init__(self, config_path: str):
+        if not config_path:
+            raise ValueError("config_path is required")
+
+        if not Path(config_path).exists():
+            raise FileNotFoundError(f"config path {config_path} does not exist")
+
+        config = ConfigParser()
+        config.read(config_path)
+
+        if _HEADING not in config:
+            raise ValueError(f"config file {config_path} is missing required section {_HEADING}")
+
+        heading = config[_HEADING]
+        self.auth_url = _get_value(heading, _AUTH_URL)
+        self.data_dir = _get_path_value(heading, _DATA_DIR)
+        self.meta_dir = _get_path_value(heading, _META_DIR)
+        self.concierge_path = _get_path_value(heading, _CONCIERGE_PATH)
+        self.file_extension_mappings = _get_path_value(heading, _FILE_EXTENSION_MAPPINGS)
+        self.dts_manifest_schema = _get_path_value(heading, _DTS_MANIFEST_SCHEMA)
+
+
+def _get_value(section: SectionProxy, key: str, required: bool = True) -> str | None:
+    if key not in section and required:
+        raise ValueError(f"Please provide {key} in the config file section {section.name}")
+    return section.get(key)
+
+def _get_path_value(section, key, required: bool = True) -> str | None:
+    value = _get_value(section, key, required=required)
+    if value is not None and value.startswith("."):
+        value = os.path.normpath(os.path.join(os.getcwd(), value))
+    return value

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -67,10 +67,7 @@ def _get_path_value(section: SectionProxy, key: str) -> str:
     TODO: This returns paths as strings, not Path-like objects, as much of the rest of the service
     expects them that way. Consider changing it later.
     """
-    value = _get_value(section, key)
-    if value is not None and value.startswith("."):
-        value = str(Path(value).absolute().resolve())
-    return value
+    return str(Path(_get_value(section, key)).absolute().resolve())
 
 
 class MissingAuthToken(Exception):

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -70,8 +70,9 @@ class StagingServiceConfig:
 def _get_value(section: SectionProxy, key: str, is_required: bool = True) -> str | None:
     """
     Returns the value for a key in the given ConfigParser section.
-    If is_required is True, and the value isn't present, this raises a ValueError.
-    If is_required is False, and the value isn't present, this returns None.
+    If is_required is True, and the key or value isn't present, this raises a ValueError.
+    If is_required is False, and the key isn't present, this returns None. If present with no
+    value, it returns an empty string.
     """
     if key not in section and is_required:
         raise ValueError(f"missing required key {key} in section {section.name}")

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -25,8 +25,7 @@ class StagingServiceConfig:
         """
         Reads the INI-formatted config file at `config_path`.
         This expects a single section - staging_service.
-        Required keys are given above - all except _TEST_TOKEN and _TEST_USER.
-        Any required key that is missing or null will raise a ValueError.
+        Any key that is missing or null will raise a ValueError.
         Raises a ValueError if the config_path is not provided.
         Raises a FileNotFoundError if config_path is not found.
         Raises a MissingAuthToken error if the AUTH_TOKEN environment variable is not provided.
@@ -63,17 +62,15 @@ class StagingServiceConfig:
             raise ValueError(f"Config file {config_path} error: " + str(err))
 
 
-def _get_value(section: SectionProxy, key: str, is_required: bool = True) -> str | None:
+def _get_value(section: SectionProxy, key: str) -> str:
     """
     Returns the value for a key in the given ConfigParser section.
-    If is_required is True, and the key or value isn't present, this raises a ValueError.
-    If is_required is False, and the key isn't present, this returns None. If present with no
-    value, it returns an empty string.
+    If the key or value isn't present, this raises a ValueError.
     """
-    if key not in section and is_required:
+    if key not in section:
         raise ValueError(f"missing required key {key} in section {section.name}")
     value = section.get(key)
-    if not value and is_required:
+    if not value:
         raise ValueError(
             f"required key {key} in section {section.name} must not be empty or all whitespace"
         )

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -75,7 +75,12 @@ def _get_value(section: SectionProxy, key: str, is_required: bool = True) -> str
     """
     if key not in section and is_required:
         raise ValueError(f"missing required key {key} in section {section.name}")
-    return section.get(key)
+    value = section.get(key)
+    if not value and is_required:
+        raise ValueError(
+            f"required key {key} in section {section.name} must not be empty or all whitespace"
+        )
+    return value
 
 
 def _get_path_value(section: SectionProxy, key: str) -> str:

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -20,6 +20,7 @@ class StagingServiceConfig:
     This requires that all values are present.
     See deployment/conf/deployment.cfg for an example.
     It also holds the service auth token from the AUTH_TOKEN environment variable.
+    TODO: update when AUTH_TOKEN is moved into the config - see issue #227
     """
 
     def __init__(self, config_path: str):
@@ -27,25 +28,29 @@ class StagingServiceConfig:
             raise ValueError("config_path is required")
 
         if not Path(config_path).exists():
-            raise FileNotFoundError(f"config path {config_path} does not exist")
+            raise FileNotFoundError(f"Config path {config_path} does not exist")
 
         config = ConfigParser()
         config.read(config_path)
 
         if _HEADING not in config:
-            raise ValueError(f"config file {config_path} is missing required section {_HEADING}")
+            raise ValueError(f"Config file {config_path} is missing required section {_HEADING}")
 
         if _ENV_AUTH_TOKEN not in os.environ or not os.environ[_ENV_AUTH_TOKEN]:
             raise MissingAuthToken("AUTH_TOKEN environment variable must be provided")
         self.auth_token = os.environ[_ENV_AUTH_TOKEN]
 
         heading = config[_HEADING]
-        self.auth_url = _get_value(heading, _AUTH_URL)
-        self.data_dir = _get_path_value(heading, _DATA_DIR)
-        self.meta_dir = _get_path_value(heading, _META_DIR)
-        self.concierge_path = _get_path_value(heading, _CONCIERGE_PATH)
-        self.file_extension_mappings = _get_path_value(heading, _FILE_EXTENSION_MAPPINGS)
-        self.dts_manifest_schema = _get_path_value(heading, _DTS_MANIFEST_SCHEMA)
+        try:
+            self.auth_url = _get_value(heading, _AUTH_URL)
+            self.data_dir = _get_path_value(heading, _DATA_DIR)
+            self.meta_dir = _get_path_value(heading, _META_DIR)
+            self.concierge_path = _get_path_value(heading, _CONCIERGE_PATH)
+            self.file_extension_mappings = _get_path_value(heading, _FILE_EXTENSION_MAPPINGS)
+            self.dts_manifest_schema = _get_path_value(heading, _DTS_MANIFEST_SCHEMA)
+        except ValueError as err:
+            # tack the file name on the error string
+            raise ValueError(f"Config file {config_path} error: " + str(err))
         self.test_token = _get_value(heading, _TEST_TOKEN, is_required=False)
         self.test_user = _get_value(heading, _TEST_USER, is_required=False)
 
@@ -57,7 +62,7 @@ def _get_value(section: SectionProxy, key: str, is_required: bool = True) -> str
     If is_required is False, and the value isn't present, this returns None.
     """
     if key not in section and is_required:
-        raise ValueError(f"Please provide {key} in the config file section {section.name}")
+        raise ValueError(f"missing required key {key} in section {section.name}")
     return section.get(key)
 
 

--- a/staging_service/config.py
+++ b/staging_service/config.py
@@ -2,6 +2,7 @@ from configparser import ConfigParser, SectionProxy
 import os
 from pathlib import Path
 
+_ENV_AUTH_TOKEN = "AUTH_TOKEN"
 _META_DIR = "META_DIR"
 _DATA_DIR = "DATA_DIR"
 _AUTH_URL = "AUTH_URL"
@@ -10,7 +11,15 @@ _FILE_EXTENSION_MAPPINGS = "FILE_EXTENSION_MAPPINGS"
 _DTS_MANIFEST_SCHEMA = "DTS_MANIFEST_SCHEMA"
 _HEADING = "staging_service"
 
+
 class StagingServiceConfig:
+    """
+    Constructs a simple config object from a passed config file path.
+    This requires that all values are present.
+    See deployment/conf/deployment.cfg for an example.
+    It also holds the service auth token from the AUTH_TOKEN environment variable.
+    """
+
     def __init__(self, config_path: str):
         if not config_path:
             raise ValueError("config_path is required")
@@ -24,6 +33,10 @@ class StagingServiceConfig:
         if _HEADING not in config:
             raise ValueError(f"config file {config_path} is missing required section {_HEADING}")
 
+        if _ENV_AUTH_TOKEN not in os.environ or not os.environ[_ENV_AUTH_TOKEN]:
+            raise MissingAuthToken("AUTH_TOKEN environment variable must be provided")
+        self.auth_token = os.environ[_ENV_AUTH_TOKEN]
+
         heading = config[_HEADING]
         self.auth_url = _get_value(heading, _AUTH_URL)
         self.data_dir = _get_path_value(heading, _DATA_DIR)
@@ -33,13 +46,32 @@ class StagingServiceConfig:
         self.dts_manifest_schema = _get_path_value(heading, _DTS_MANIFEST_SCHEMA)
 
 
-def _get_value(section: SectionProxy, key: str, required: bool = True) -> str | None:
-    if key not in section and required:
+def _get_value(section: SectionProxy, key: str) -> str:
+    """
+    Returns the value for a key in the given ConfigParser section.
+    If not present, this raises a ValueError
+    """
+    if key not in section:
         raise ValueError(f"Please provide {key} in the config file section {section.name}")
     return section.get(key)
 
-def _get_path_value(section, key, required: bool = True) -> str | None:
-    value = _get_value(section, key, required=required)
+
+def _get_path_value(section: SectionProxy, key: str) -> str:
+    """
+    Returns a value for a key that's expected to be a file path. This resolves the path and makes
+    it absolute. I.e. a path like ./foo becomes /path/to/local/dir/foo
+    TODO: This returns paths as strings, not Path-like objects, as much of the rest of the service
+    expects them that way. Consider changing it later.
+    TODO: Consider adding path validation here for required paths (like the data directory or the
+    DTS manifest schema file)
+    """
+    value = _get_value(section, key)
     if value is not None and value.startswith("."):
-        value = os.path.normpath(os.path.join(os.getcwd(), value))
+        value = str(Path(value).absolute().resolve())
     return value
+
+
+class MissingAuthToken(Exception):
+    """Should be raised if the auth token environment variable is missing or empty"""
+
+    pass

--- a/tests/import_specifications/test_individual_parsers.py
+++ b/tests/import_specifications/test_individual_parsers.py
@@ -40,7 +40,7 @@ def temp_dir_fixture() -> Generator[Path, None, None]:
 @pytest.fixture(scope="module")
 def dts_validator() -> Generator[Draft202012Validator, None, None]:
     config = bootstrap_config()
-    with open(config["staging_service"]["DTS_MANIFEST_SCHEMA"]) as dts_schema_file:
+    with open(config.dts_manifest_schema) as dts_schema_file:
         schema = json.load(dts_schema_file)
         yield Draft202012Validator(schema)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,6 +22,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import staging_service.app as app
+from staging_service.config import StagingServiceConfig
 import staging_service.globus as globus
 import staging_service.utils as utils
 from staging_service.AutoDetectUtils import AutoDetectUtils
@@ -37,18 +38,24 @@ if os.environ.get("KB_DEPLOYMENT_CONFIG") is None:
 
 decoder = json.JSONDecoder()
 
-config = configparser.ConfigParser()
-config.read(os.environ["KB_DEPLOYMENT_CONFIG"])
+config = StagingServiceConfig(os.environ["KB_DEPLOYMENT_CONFIG"])
 
-DATA_DIR = config["staging_service"]["DATA_DIR"]
-META_DIR = config["staging_service"]["META_DIR"]
-AUTH_URL = config["staging_service"]["AUTH_URL"]
-if DATA_DIR.startswith("."):
-    DATA_DIR = os.path.normpath(os.path.join(os.getcwd(), DATA_DIR))
-if META_DIR.startswith("."):
-    META_DIR = os.path.normpath(os.path.join(os.getcwd(), META_DIR))
-utils.Path._DATA_DIR = DATA_DIR
-utils.Path._META_DIR = META_DIR
+utils.Path._DATA_DIR = config.data_dir
+utils.Path._META_DIR = config.meta_dir
+AUTH_URL = config.auth_url
+
+# config = configparser.ConfigParser()
+# config.read(os.environ["KB_DEPLOYMENT_CONFIG"])
+
+# DATA_DIR = config["staging_service"]["DATA_DIR"]
+# META_DIR = config["staging_service"]["META_DIR"]
+# AUTH_URL = config["staging_service"]["AUTH_URL"]
+# if DATA_DIR.startswith("."):
+#     DATA_DIR = os.path.normpath(os.path.join(os.getcwd(), DATA_DIR))
+# if META_DIR.startswith("."):
+#     META_DIR = os.path.normpath(os.path.join(os.getcwd(), META_DIR))
+# utils.Path._DATA_DIR = DATA_DIR
+# utils.Path._META_DIR = META_DIR
 
 
 def asyncgiven(**kwargs):
@@ -118,7 +125,7 @@ class AppClient:
 
 
 class FileUtil:
-    def __init__(self, base_dir=DATA_DIR):
+    def __init__(self, base_dir=config.data_dir):
         self.base_dir = base_dir
 
     def __enter__(self):
@@ -184,9 +191,9 @@ def test_path_cases(username_first, username_rest):
 def test_path_sanitation(username_first, username_rest, path):
     username = username_first + username_rest
     validated = utils.Path.validate_path(username, path)
-    assert validated.full_path.startswith(DATA_DIR)
+    assert validated.full_path.startswith(config.data_dir)
     assert validated.user_path.startswith(username)
-    assert validated.metadata_path.startswith(META_DIR)
+    assert validated.metadata_path.startswith(config.meta_dir)
     assert validated.full_path.find("/..") == -1
     assert validated.user_path.find("/..") == -1
     assert validated.metadata_path.find("/..") == -1
@@ -197,7 +204,7 @@ def test_path_sanitation(username_first, username_rest, path):
 
 @asyncgiven(txt=st.text())
 async def test_cmd(txt):
-    with FileUtil(DATA_DIR) as fs:
+    with FileUtil(config.data_dir) as fs:
         d = fs.make_dir("test")
         assert "" == await utils.run_command("ls", d)
         f = fs.make_file("test/test2", txt)
@@ -347,7 +354,7 @@ async def test_metadata():
             assert not json.get("isFolder")
 
             # testing corrupted metadata file
-            path = os.path.join(META_DIR, TEST_USER, "test", "test_file_1")
+            path = os.path.join(config.meta_dir, TEST_USER, "test", "test_file_1")
             with open(path, encoding="utf-8", mode="w") as f:
                 f.write('{"source": "Unknown"}')
             res3 = await cli.get(
@@ -1275,7 +1282,7 @@ def test_bulk_specification_dts_fail_bad_schema():
 
 def test_load_and_validate_schema_good():
     # TODO: update this after updating how config is handled
-    schema_file = config["staging_service"]["DTS_MANIFEST_SCHEMA"]
+    schema_file = config.dts_manifest_schema
     validator = app.load_and_validate_schema(schema_file)
     assert isinstance(validator, jsonschema.Draft202012Validator)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -35,13 +35,13 @@ if os.environ.get("KB_DEPLOYMENT_CONFIG") is None:
 
     bootstrap()
 
-decoder = json.JSONDecoder()
+DECODER = json.JSONDecoder()
 
-config = StagingServiceConfig(os.environ["KB_DEPLOYMENT_CONFIG"])
+CONFIG = StagingServiceConfig(os.environ["KB_DEPLOYMENT_CONFIG"])
 
-utils.Path._DATA_DIR = config.data_dir
-utils.Path._META_DIR = config.meta_dir
-AUTH_URL = config.auth_url
+utils.Path._DATA_DIR = CONFIG.data_dir
+utils.Path._META_DIR = CONFIG.meta_dir
+AUTH_URL = CONFIG.auth_url
 
 
 def asyncgiven(**kwargs):
@@ -111,7 +111,7 @@ class AppClient:
 
 
 class FileUtil:
-    def __init__(self, base_dir=config.data_dir):
+    def __init__(self, base_dir=CONFIG.data_dir):
         self.base_dir = base_dir
 
     def __enter__(self):
@@ -177,9 +177,9 @@ def test_path_cases(username_first, username_rest):
 def test_path_sanitation(username_first, username_rest, path):
     username = username_first + username_rest
     validated = utils.Path.validate_path(username, path)
-    assert validated.full_path.startswith(config.data_dir)
+    assert validated.full_path.startswith(CONFIG.data_dir)
     assert validated.user_path.startswith(username)
-    assert validated.metadata_path.startswith(config.meta_dir)
+    assert validated.metadata_path.startswith(CONFIG.meta_dir)
     assert validated.full_path.find("/..") == -1
     assert validated.user_path.find("/..") == -1
     assert validated.metadata_path.find("/..") == -1
@@ -190,7 +190,7 @@ def test_path_sanitation(username_first, username_rest, path):
 
 @asyncgiven(txt=st.text())
 async def test_cmd(txt):
-    with FileUtil(config.data_dir) as fs:
+    with FileUtil(CONFIG.data_dir) as fs:
         d = fs.make_dir("test")
         assert "" == await utils.run_command("ls", d)
         f = fs.make_file("test/test2", txt)
@@ -209,7 +209,7 @@ async def test_cmd(txt):
 async def do_auth_test(
     token: str | None, cookies: dict[str, str] | None, expected_status: int, expected_text: str
 ):
-    async with await AppClient.create(config, token, cookies=cookies) as cli:
+    async with await AppClient.create(CONFIG, token, cookies=cookies) as cli:
         resp = await cli.get("/test-auth")
         assert resp.status == expected_status
         text = await resp.text()
@@ -246,7 +246,7 @@ async def test_auth_fail_service_err():
 
 
 async def test_service():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.get("/test-service")
         assert resp.status == 200
         text = await resp.text()
@@ -257,7 +257,7 @@ async def test_jgi_metadata():
     txt = "testing text\n"
     jgi_metadata = '{"file_owner": "sdm", "added_date": "2013-08-12T00:21:53.844000"}'
 
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_jgi.fastq"), txt)
@@ -265,7 +265,7 @@ async def test_jgi_metadata():
             res1 = await cli.get(os.path.join("jgi-metadata", "test", "test_jgi.fastq"))
             assert res1.status == 200
             json_text = await res1.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             expected_keys = ["file_owner", "added_date"]
             assert set(json.keys()) >= set(expected_keys)
             assert json.get("file_owner") == "sdm"
@@ -280,14 +280,14 @@ async def test_jgi_metadata():
 
 async def test_metadata():
     txt = "testing text\n"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
             res1 = await cli.get(os.path.join("metadata", "test", "test_file_1"))
             assert res1.status == 200
             json_text = await res1.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             expected_keys = [
                 "source",
                 "md5",
@@ -316,7 +316,7 @@ async def test_metadata():
             )
             assert res2.status == 200
             json_text = await res2.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             expected_keys = [
                 "source",
                 "md5",
@@ -340,7 +340,7 @@ async def test_metadata():
             assert not json.get("isFolder")
 
             # testing corrupted metadata file
-            path = os.path.join(config.meta_dir, TEST_USER, "test", "test_file_1")
+            path = os.path.join(CONFIG.meta_dir, TEST_USER, "test", "test_file_1")
             with open(path, encoding="utf-8", mode="w") as f:
                 f.write('{"source": "Unknown"}')
             res3 = await cli.get(
@@ -348,7 +348,7 @@ async def test_metadata():
             )
             assert res3.status == 200
             json_text = await res3.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             expected_keys = [
                 "source",
                 "md5",
@@ -374,7 +374,7 @@ async def test_metadata():
 
 async def test_define_upa():
     txt = "testing text\n"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
@@ -399,7 +399,7 @@ async def test_define_upa():
             )
             assert res3.status == 200
             json_text = await res3.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             expected_keys = [
                 "source",
                 "md5",
@@ -446,7 +446,7 @@ async def test_define_upa():
 
 async def test_mv():
     txt = "testing text\n"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
@@ -457,7 +457,7 @@ async def test_mv():
             )
             assert res1.status == 200
             json_text = await res1.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 1
             assert json[0]["name"] == "test_file_1"
 
@@ -475,7 +475,7 @@ async def test_mv():
             )
             assert res3.status == 200
             json_text = await res3.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 1
             assert json[0]["name"] == "test_file_2"
 
@@ -509,7 +509,7 @@ async def test_mv():
 
 async def test_delete():
     txt = "testing text\n"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
@@ -520,7 +520,7 @@ async def test_delete():
             )
             assert res1.status == 200
             json_text = await res1.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 1
             assert json[0]["name"] == "test_file_1"
 
@@ -537,7 +537,7 @@ async def test_delete():
             )
             assert res3.status == 200
             json_text = await res3.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 0
 
             # testing non-existing file
@@ -549,7 +549,7 @@ async def test_delete():
 
 async def test_list():
     txt = "testing text"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
@@ -566,7 +566,7 @@ async def test_list():
             res3 = await cli.get("/list/")
             assert res3.status == 200
             json_text = await res3.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             file_folder_count = [file_json["isFolder"] for file_json in json]
             assert json[0]["isFolder"] is True
             assert json[0]["name"] == "test"
@@ -579,7 +579,7 @@ async def test_list():
             res4 = await cli.get("/list")
             assert res4.status == 200
             json_text = await res4.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             file_folder_count = [file_json["isFolder"] for file_json in json]
             assert json[0]["isFolder"] is True
             assert json[0]["name"] == "test"
@@ -592,7 +592,7 @@ async def test_list():
             res5 = await cli.get(os.path.join("list", "test"))
             assert res5.status == 200
             json_text = await res5.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             file_folder_count = [file_json["isFolder"] for file_json in json]
             # 1 sub-directory, 1 file in sub-directory and 1 file in root
             assert len(file_folder_count) == 3
@@ -607,7 +607,7 @@ async def test_list():
             res6 = await cli.get("/list/")
             assert res6.status == 200
             json_text = await res6.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
 
             file_names = [file_json["name"] for file_json in json if not file_json["isFolder"]]
             assert ".test_file_1" not in file_names  # NOSONAR python:S1192
@@ -618,7 +618,7 @@ async def test_list():
             res7 = await cli.get("/list/", params={"showHidden": "True"})
             assert res7.status == 200
             json_text = await res7.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             file_names = [file_json["name"] for file_json in json if not file_json["isFolder"]]
             assert ".test_file_1" in file_names  # NOSONAR python:S1192
             assert ".globus_id" in file_names
@@ -629,7 +629,7 @@ async def test_list():
 @settings(deadline=None)
 @asyncgiven(txt=st.text())
 async def test_download(txt):
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
@@ -643,7 +643,7 @@ async def test_download(txt):
 
 
 async def test_download_errors():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
 
@@ -659,7 +659,7 @@ async def test_download_errors():
 
 async def test_similar():
     txt = "testing text"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1.fq"), txt)
@@ -675,7 +675,7 @@ async def test_similar():
             res1 = await cli.get("similar/test/test_file_1.fq")
             assert res1.status == 200
             json_text = await res1.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 2
             assert json[0].get("name") in ["test_file_2.fq", "test_file_right.fq"]
             assert json[1].get("name") in ["test_file_2.fq", "test_file_right.fq"]
@@ -691,7 +691,7 @@ async def test_similar():
 
 async def test_existence():
     txt = "testing text"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test_file_1"), txt)
@@ -708,7 +708,7 @@ async def test_existence():
             res1 = await cli.get("existence/test_file_1")
             assert res1.status == 200
             json_text = await res1.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert json["exists"] is True
             assert json["isFolder"] is False
 
@@ -716,7 +716,7 @@ async def test_existence():
             res2 = await cli.get("existence/test_file_2")
             assert res2.status == 200
             json_text = await res2.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert json["exists"] is True
             assert json["isFolder"] is False
 
@@ -724,7 +724,7 @@ async def test_existence():
             res3 = await cli.get("existence/test_sub_dir")
             assert res3.status == 200
             json_text = await res3.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert json["exists"] is True
             assert json["isFolder"] is True
 
@@ -732,21 +732,21 @@ async def test_existence():
             res4 = await cli.get("existence/fake_file")
             assert res4.status == 200
             json_text = await res4.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert json["exists"] is False
             assert json["isFolder"] is False
 
             res5 = await cli.get("existence/test_sub")
             assert res5.status == 200
             json_text = await res5.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert json["exists"] is False
             assert json["isFolder"] is False
 
 
 async def test_search():
     txt = "testing text"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fs:
             fs.make_dir(os.path.join(TEST_USER, "test"))
             fs.make_file(os.path.join(TEST_USER, "test", "test1"), txt)
@@ -755,23 +755,23 @@ async def test_search():
             res1 = await cli.get("search/")
             assert res1.status == 200
             json_text = await res1.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 4
             res2 = await cli.get("search/test1")
             assert res2.status == 200
             json_text = await res2.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 1
             res3 = await cli.get("search/test2")
             assert res3.status == 200
             json_text = await res3.text()
-            json = decoder.decode(json_text)
+            json = DECODER.decode(json_text)
             assert len(json) == 2
 
 
 async def test_upload():
     txt = "testing text\n"
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         # testing missing body
         res1 = await cli.post("upload")
         assert res1.status == 400
@@ -791,7 +791,7 @@ async def _upload_file_fail_filename(filename: str, err: str):
     # Note two file uploads in a row causes a test error:
     # https://github.com/aio-libs/aiohttp/issues/3968
     async with await AppClient.create(
-        config, TEST_TOKEN
+        CONFIG, TEST_TOKEN
     ) as cli:  # username is ignored by AppClient
         formdata = FormData()
         formdata.add_field("destPath", "/")
@@ -840,7 +840,7 @@ async def test_directory_decompression(contents):
         ("bztar", ".tar.bz"),
         ("tar", ".tar"),
     ]
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         for method, extension in methods:
             with FileUtil() as fs:
                 d = fs.make_dir(os.path.join(TEST_USER, dirname))
@@ -891,7 +891,7 @@ async def test_file_decompression(contents):
         return
     methods = [("gzip", ".gz"), ("bzip2", ".bz2")]
 
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         for method, extension in methods:
             with FileUtil() as fs:
                 d = fs.make_dir(os.path.join(TEST_USER, dirname))
@@ -923,7 +923,7 @@ async def test_importer_mappings():
     data = {"file_list": ["file1.txt"]}
     qs1 = urlencode(data, doseq=True)
 
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.get(f"importer_mappings/?{qs1}")
         assert resp.status == 200
         text = await resp.json()
@@ -935,7 +935,7 @@ async def test_importer_mappings():
     data = {"file_list": ["file1.txt", "file.tar.gz"]}
     qs2 = urlencode(data, doseq=True)
 
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.get(f"importer_mappings/?{qs2}", data=data)
         assert resp.status == 200
         text = await resp.json()
@@ -951,7 +951,7 @@ async def test_importer_mappings():
     # A dict is passed in
     data = {"file_list": [{}]}
     qs3 = urlencode(data, doseq=True)
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.get(f"importer_mappings/?{qs3}", data=data)
         assert resp.status == 200
         text = await resp.json()
@@ -969,7 +969,7 @@ async def test_importer_mappings():
 
     for data in bad_data:
         qsd = urlencode(data, doseq=True)
-        async with await AppClient.create(config, TEST_TOKEN) as cli:
+        async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
             resp = await cli.get(f"importer_mappings/?{qsd}")
             assert resp.status == 400
             text = await resp.text()
@@ -978,7 +978,7 @@ async def test_importer_mappings():
 
 async def test_bulk_specification_success():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(f"{TEST_USER}/somefolder")
             base = Path(fu.base_dir) / TEST_USER
@@ -1063,7 +1063,7 @@ async def test_bulk_specification_success():
 
 
 async def test_bulk_specification_dts_success():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
             dts_dir = f"{TEST_USER}/{sub_dir}"
@@ -1155,7 +1155,7 @@ async def test_bulk_specification_dts_success():
 
 
 async def test_bulk_specification_dts_fail_json_without_dts():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
             dts_dir = f"{TEST_USER}/{sub_dir}"
@@ -1196,7 +1196,7 @@ async def test_bulk_specification_dts_fail_json_without_dts():
 
 
 async def test_bulk_specification_dts_fail_wrong_format():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
             dts_dir = f"{TEST_USER}/{sub_dir}"
@@ -1231,7 +1231,7 @@ async def test_bulk_specification_dts_fail_wrong_format():
     ],
 )
 async def test_bulk_specification_dts_fail_wrong_extension(manifest: str, expected: str):
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             sub_dir = "dts_folder"
             dts_dir = f"{TEST_USER}/{sub_dir}"
@@ -1268,7 +1268,7 @@ def test_bulk_specification_dts_fail_bad_schema():
 
 def test_load_and_validate_schema_good():
     # TODO: update this after updating how config is handled
-    schema_file = config.dts_manifest_schema
+    schema_file = CONFIG.dts_manifest_schema
     validator = app.load_and_validate_schema(schema_file)
     assert isinstance(validator, jsonschema.Draft202012Validator)
 
@@ -1304,7 +1304,7 @@ def test_load_and_validate_schema_bad(tmp_path: Path):
 
 
 async def test_bulk_specification_fail_no_files():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         for f in ["", "?files=", "?files=  ,   ,,   ,  "]:
             resp = await cli.get(f"bulk_specification/{f}")
             jsn = await resp.json()
@@ -1313,7 +1313,7 @@ async def test_bulk_specification_fail_no_files():
 
 
 async def test_bulk_specification_fail_not_found():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(f"{TEST_USER}/otherfolder")
             base = Path(fu.base_dir) / TEST_USER
@@ -1340,7 +1340,7 @@ async def test_bulk_specification_fail_parse_fail():
     Tests a number of different parse fail cases, including incorrect file types.
     Also tests that all the errors are combined correctly.
     """
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(f"{TEST_USER}/otherfolder")
             base = Path(fu.base_dir) / TEST_USER
@@ -1449,7 +1449,7 @@ async def test_bulk_specification_fail_parse_fail():
 
 
 async def test_bulk_specification_fail_column_count():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(TEST_USER)
             base = Path(fu.base_dir) / TEST_USER
@@ -1522,7 +1522,7 @@ async def test_bulk_specification_fail_column_count():
 
 
 async def test_bulk_specification_fail_multiple_specs_per_type():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(TEST_USER)
             base = Path(fu.base_dir) / TEST_USER
@@ -1615,7 +1615,7 @@ async def test_bulk_specification_fail_multiple_specs_per_type_excel():
     Test an excel file with an internal data type collision.
     This is the only case when all 5 error fields are filled out.
     """
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(TEST_USER)
             base = Path(fu.base_dir) / TEST_USER
@@ -1690,7 +1690,7 @@ _IMPORT_SPEC_TEST_DATA = {
 
 async def test_write_bulk_specification_success_csv():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(TEST_USER)
             resp = await cli.post(
@@ -1733,7 +1733,7 @@ async def test_write_bulk_specification_success_csv():
 
 async def test_write_bulk_specification_success_tsv():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(TEST_USER)
             types = dict(_IMPORT_SPEC_TEST_DATA)
@@ -1778,7 +1778,7 @@ async def test_write_bulk_specification_success_tsv():
 
 async def test_write_bulk_specification_success_excel():
     # In other tests a username is passed to AppClient but AppClient completely ignores it...
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         with FileUtil() as fu:
             fu.make_dir(TEST_USER)
             resp = await cli.post(
@@ -1825,7 +1825,7 @@ async def test_write_bulk_specification_success_excel():
 
 
 async def test_write_bulk_specification_fail_wrong_data_type():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.post("write_bulk_specification/", data="foo")
         js = await resp.json()
         assert js == {"error": "Required content-type is application/json"}
@@ -1833,7 +1833,7 @@ async def test_write_bulk_specification_fail_wrong_data_type():
 
 
 async def test_write_bulk_specification_fail_no_content_length():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.post(
             "write_bulk_specification", headers={"content-type": "application/json"}
         )
@@ -1843,7 +1843,7 @@ async def test_write_bulk_specification_fail_no_content_length():
 
 
 async def test_write_bulk_specification_fail_large_input():
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.post("write_bulk_specification/", json="a" * (1024 * 1024 - 2))
         txt = await resp.text()
         # this seems to be a built in (somewhat inaccurate) server feature
@@ -1852,7 +1852,7 @@ async def test_write_bulk_specification_fail_large_input():
 
 
 async def _write_bulk_specification_json_fail(json: Any, err: str):
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.post("write_bulk_specification", json=json)
         js = await resp.json()
         assert js == {"error": err}
@@ -1901,7 +1901,7 @@ async def test_importer_filetypes():
     """
     Only checks a few example entries since the list may expand over time
     """
-    async with await AppClient.create(config, TEST_TOKEN) as cli:
+    async with await AppClient.create(CONFIG, TEST_TOKEN) as cli:
         resp = await cli.get("importer_filetypes")
         js = await resp.json()
         assert set(js.keys()) == {"datatype_to_filetype", "filetype_to_extensions"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,4 @@
 import asyncio
-import configparser
 import hashlib
 import json
 import os
@@ -44,19 +43,6 @@ utils.Path._DATA_DIR = config.data_dir
 utils.Path._META_DIR = config.meta_dir
 AUTH_URL = config.auth_url
 
-# config = configparser.ConfigParser()
-# config.read(os.environ["KB_DEPLOYMENT_CONFIG"])
-
-# DATA_DIR = config["staging_service"]["DATA_DIR"]
-# META_DIR = config["staging_service"]["META_DIR"]
-# AUTH_URL = config["staging_service"]["AUTH_URL"]
-# if DATA_DIR.startswith("."):
-#     DATA_DIR = os.path.normpath(os.path.join(os.getcwd(), DATA_DIR))
-# if META_DIR.startswith("."):
-#     META_DIR = os.path.normpath(os.path.join(os.getcwd(), META_DIR))
-# utils.Path._DATA_DIR = DATA_DIR
-# utils.Path._META_DIR = META_DIR
-
 
 def asyncgiven(**kwargs):
     """alternative to hypothesis.given decorator for async"""
@@ -74,7 +60,7 @@ def asyncgiven(**kwargs):
     return real_decorator
 
 
-async def mock_globus_app(config: configparser.ConfigParser):
+async def mock_globus_app(config: StagingServiceConfig):
     application = await app.app_factory(config)
 
     async def mock_globus_id(*args, **kwargs):
@@ -88,7 +74,7 @@ class AppClient:
     @classmethod
     async def create(
         cls,
-        config: configparser.ConfigParser,
+        config: StagingServiceConfig,
         auth_token: str | None,
         cookies: dict[str, str] | None = None,
     ) -> "AppClient":
@@ -285,7 +271,7 @@ async def test_jgi_metadata():
             assert json.get("file_owner") == "sdm"
             assert json.get("added_date") == "2013-08-12T00:21:53.844000"
 
-            # testing non-existing jbi metadata file
+            # testing non-existing jgi metadata file
             res1 = await cli.get(
                 os.path.join("jgi-metadata", "test", "non_existing.1617.2.1467.fastq")
             )
@@ -439,7 +425,7 @@ async def test_define_upa():
             assert json.get("UPA") is not None
             assert json.get("UPA") == "test_UPA"
 
-            # testing non-existing jbi metadata file
+            # testing non-existing jgi metadata file
             res4 = await cli.post(
                 os.path.join("define-upa", "test", "non_existing.test_file_1"),
                 data={"UPA": "test_UPA"},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,7 +139,6 @@ def test_path_resolution(tmp_path):
         "file_extension_mappings",
         "dts_manifest_schema",
     ]
-    print(config.data_dir)
     for key in config_keys:
         value = getattr(config, key)
         assert Path(value).is_absolute()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,7 @@ DEFAULT_CONFIG_DICT = {
     "META_DIR": META_DIR,
     "CONCIERGE_PATH": CONCIERGE_PATH,
     "FILE_EXTENSION_MAPPINGS": FILE_EXTENSION_MAPPINGS,
-    "DTS_MANIFEST_SCHEMA": DTS_MANIFEST_SCHEMA
+    "DTS_MANIFEST_SCHEMA": DTS_MANIFEST_SCHEMA,
 }
 
 
@@ -50,12 +50,22 @@ def validate_config(config: StagingServiceConfig, **kwargs):
     These can be updated to your use case by changing the relevant kwarg.
     See test_valid_config_with_test_info for an example.
     """
-    config_attrs = ["auth_url", "data_dir", "meta_dir", "concierge_path", "file_extension_mappings", "dts_manifest_schema", "auth_token", "test_token", "test_user"]
+    config_attrs = [
+        "auth_url",
+        "data_dir",
+        "meta_dir",
+        "concierge_path",
+        "file_extension_mappings",
+        "dts_manifest_schema",
+        "auth_token",
+        "test_token",
+        "test_user",
+    ]
     config_values = {key.lower(): value for key, value in DEFAULT_CONFIG_DICT.items()}
     config_values = config_values | {
         "test_token": TEST_TOKEN,
         "test_user": TEST_USER,
-        "auth_token": AUTH_TOKEN
+        "auth_token": AUTH_TOKEN,
     }
     config_values = config_values | kwargs
     for attr in config_attrs:
@@ -72,8 +82,7 @@ def test_valid_config_with_test_info(tmp_path):
     fake_token = "fake_token"
     fake_user = "fake_user"
     config_with_tokens = dummy_config(
-        VALID_HEADER,
-        DEFAULT_CONFIG_DICT | {"TEST_TOKEN": fake_token, "TEST_USER": fake_user}
+        VALID_HEADER, DEFAULT_CONFIG_DICT | {"TEST_TOKEN": fake_token, "TEST_USER": fake_user}
     )
     config_path = write_config_file(tmp_path, config_with_tokens)
     config = StagingServiceConfig(config_path)
@@ -94,7 +103,9 @@ def test_missing_config_file():
 def test_missing_heading(tmp_path):
     bad_config = "[wrong_section]\nfoo=bar"
     config_path = write_config_file(tmp_path, bad_config)
-    with pytest.raises(ValueError, match=f"config file {config_path} is missing required section {VALID_HEADER}"):
+    with pytest.raises(
+        ValueError, match=f"config file {config_path} is missing required section {VALID_HEADER}"
+    ):
         StagingServiceConfig(config_path)
 
 
@@ -103,7 +114,9 @@ def test_missing_required_key(tmp_path, missing_key):
     missing_config_dict = DEFAULT_CONFIG_DICT.copy()
     del missing_config_dict[missing_key]
     config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, missing_config_dict))
-    with pytest.raises(ValueError, match=f"Please provide {missing_key} in the config file section {VALID_HEADER}"):
+    with pytest.raises(
+        ValueError, match=f"Please provide {missing_key} in the config file section {VALID_HEADER}"
+    ):
         StagingServiceConfig(config_path)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ META_DIR = "/kb/deployment/data/metadata"
 CONCIERGE_PATH = "/kbaseconcierge"
 FILE_EXTENSION_MAPPINGS = "/kb/deployment/file_mappings.json"
 DTS_MANIFEST_SCHEMA = "/kb/deployment/dts_manifest_schema.json"
+# TODO update the below when config file templates are in place - issue #227
 TEST_TOKEN = None
 TEST_USER = None
 AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
@@ -96,7 +97,7 @@ def test_missing_config_path():
 
 def test_missing_config_file():
     missing_file = "missing.cfg"
-    with pytest.raises(FileNotFoundError, match=f"config path {missing_file} does not exist"):
+    with pytest.raises(FileNotFoundError, match=f"Config path {missing_file} does not exist"):
         StagingServiceConfig(missing_file)
 
 
@@ -104,7 +105,7 @@ def test_missing_heading(tmp_path):
     bad_config = "[wrong_section]\nfoo=bar"
     config_path = write_config_file(tmp_path, bad_config)
     with pytest.raises(
-        ValueError, match=f"config file {config_path} is missing required section {VALID_HEADER}"
+        ValueError, match=f"Config file {config_path} is missing required section {VALID_HEADER}"
     ):
         StagingServiceConfig(config_path)
 
@@ -115,7 +116,7 @@ def test_missing_required_key(tmp_path, missing_key):
     del missing_config_dict[missing_key]
     config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, missing_config_dict))
     with pytest.raises(
-        ValueError, match=f"Please provide {missing_key} in the config file section {VALID_HEADER}"
+        ValueError, match=f"Config file {config_path} error: missing required key {missing_key} in section {VALID_HEADER}"
     ):
         StagingServiceConfig(config_path)
 
@@ -144,6 +145,7 @@ def test_path_resolution(tmp_path):
         assert Path(value).is_absolute()
 
 
+# TODO remove once AUTH_TOKEN becomes part of the config file (see issue #228)
 def test_missing_auth_token(monkeypatch, tmp_path):
     monkeypatch.delenv("AUTH_TOKEN")
     config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, DEFAULT_CONFIG_DICT))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,8 +11,6 @@ CONCIERGE_PATH = "/kbaseconcierge"
 FILE_EXTENSION_MAPPINGS = "/kb/deployment/file_mappings.json"
 DTS_MANIFEST_SCHEMA = "/kb/deployment/dts_manifest_schema.json"
 # TODO update the below when config file templates are in place - issue #228
-TEST_TOKEN = None
-TEST_USER = None
 AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
 
 VALID_HEADER_NAME = "staging_service"
@@ -46,8 +44,7 @@ def validate_config(config: StagingServiceConfig, **kwargs):
     """
     Not the prettiest validator, but avoids a zillion kwargs.
     This validates that each attribute in the config file is as expected.
-    Default values are given in DEFAULT_CONFIG_DICT above, along with a default
-    None for test_token and test_user.
+    Default values are given in DEFAULT_CONFIG_DICT above.
     The default auth_token is taken from the environment variable AUTH_TOKEN.
     These can be updated to your use case by changing the relevant kwarg.
     See test_valid_config_with_test_info for an example.
@@ -60,13 +57,9 @@ def validate_config(config: StagingServiceConfig, **kwargs):
         "file_extension_mappings",
         "dts_manifest_schema",
         "auth_token",
-        "test_token",
-        "test_user",
     ]
     config_values = {key.lower(): value for key, value in DEFAULT_CONFIG_DICT.items()}
     config_values = config_values | {
-        "test_token": TEST_TOKEN,
-        "test_user": TEST_USER,
         "auth_token": AUTH_TOKEN,
     }
     config_values = config_values | kwargs
@@ -78,17 +71,6 @@ def test_valid_config(tmp_path):
     config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, DEFAULT_CONFIG_DICT))
     config = StagingServiceConfig(config_path)
     validate_config(config)
-
-
-def test_valid_config_with_test_info(tmp_path):
-    fake_token = "fake_token"
-    fake_user = "fake_user"
-    config_with_tokens = dummy_config(
-        VALID_HEADER, DEFAULT_CONFIG_DICT | {"TEST_TOKEN": fake_token, "TEST_USER": fake_user}
-    )
-    config_path = write_config_file(tmp_path, config_with_tokens)
-    config = StagingServiceConfig(config_path)
-    validate_config(config, test_token=fake_token, test_user=fake_user)
 
 
 def test_missing_config_path():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,10 +10,13 @@ META_DIR = "/kb/deployment/data/metadata"
 CONCIERGE_PATH = "/kbaseconcierge"
 FILE_EXTENSION_MAPPINGS = "/kb/deployment/file_mappings.json"
 DTS_MANIFEST_SCHEMA = "/kb/deployment/dts_manifest_schema.json"
+TEST_TOKEN = None
+TEST_USER = None
+AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
 
 VALID_HEADER = "[staging_service]"
 
-VALID_CONFIG_DICT = {
+DEFAULT_CONFIG_DICT = {
     "AUTH_URL": AUTH_URL,
     "DATA_DIR": DATA_DIR,
     "META_DIR": META_DIR,
@@ -37,17 +40,44 @@ def write_config_file(config_dir: Path, content: str) -> str:
     return str(file)
 
 
-def test_valid_config(tmp_path):
-    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, VALID_CONFIG_DICT))
-    config = StagingServiceConfig(config_path)
+def validate_config(config: StagingServiceConfig, **kwargs):
+    """
+    Not the prettiest validator, but avoids a zillion kwargs.
+    This validates that each attribute in the config file is as expected.
+    Default values are given in DEFAULT_CONFIG_DICT above, along with a default
+    None for test_token and test_user.
+    The default auth_token is taken from the environment variable AUTH_TOKEN.
+    These can be updated to your use case by changing the relevant kwarg.
+    See test_valid_config_with_test_info for an example.
+    """
+    config_attrs = ["auth_url", "data_dir", "meta_dir", "concierge_path", "file_extension_mappings", "dts_manifest_schema", "auth_token", "test_token", "test_user"]
+    config_values = {key.lower(): value for key, value in DEFAULT_CONFIG_DICT.items()}
+    config_values = config_values | {
+        "test_token": TEST_TOKEN,
+        "test_user": TEST_USER,
+        "auth_token": AUTH_TOKEN
+    }
+    config_values = config_values | kwargs
+    for attr in config_attrs:
+        assert getattr(config, attr) == config_values[attr]
 
-    assert config.auth_url == AUTH_URL
-    assert config.data_dir == DATA_DIR
-    assert config.meta_dir == META_DIR
-    assert config.concierge_path == CONCIERGE_PATH
-    assert config.file_extension_mappings == FILE_EXTENSION_MAPPINGS
-    assert config.dts_manifest_schema == DTS_MANIFEST_SCHEMA
-    assert config.auth_token == os.environ["AUTH_TOKEN"]
+
+def test_valid_config(tmp_path):
+    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, DEFAULT_CONFIG_DICT))
+    config = StagingServiceConfig(config_path)
+    validate_config(config)
+
+
+def test_valid_config_with_test_info(tmp_path):
+    fake_token = "fake_token"
+    fake_user = "fake_user"
+    config_with_tokens = dummy_config(
+        VALID_HEADER,
+        DEFAULT_CONFIG_DICT | {"TEST_TOKEN": fake_token, "TEST_USER": fake_user}
+    )
+    config_path = write_config_file(tmp_path, config_with_tokens)
+    config = StagingServiceConfig(config_path)
+    validate_config(config, test_token=fake_token, test_user=fake_user)
 
 
 def test_missing_config_path():
@@ -68,9 +98,9 @@ def test_missing_heading(tmp_path):
         StagingServiceConfig(config_path)
 
 
-@pytest.mark.parametrize("missing_key", VALID_CONFIG_DICT.keys())
+@pytest.mark.parametrize("missing_key", DEFAULT_CONFIG_DICT.keys())
 def test_missing_required_key(tmp_path, missing_key):
-    missing_config_dict = VALID_CONFIG_DICT.copy()
+    missing_config_dict = DEFAULT_CONFIG_DICT.copy()
     del missing_config_dict[missing_key]
     config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, missing_config_dict))
     with pytest.raises(ValueError, match=f"Please provide {missing_key} in the config file section {VALID_HEADER}"):
@@ -96,6 +126,7 @@ def test_path_resolution(tmp_path):
         "file_extension_mappings",
         "dts_manifest_schema",
     ]
+    print(config.data_dir)
     for key in config_keys:
         value = getattr(config, key)
         assert Path(value).is_absolute()
@@ -103,6 +134,6 @@ def test_path_resolution(tmp_path):
 
 def test_missing_auth_token(monkeypatch, tmp_path):
     monkeypatch.delenv("AUTH_TOKEN")
-    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, VALID_CONFIG_DICT))
+    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, DEFAULT_CONFIG_DICT))
     with pytest.raises(MissingAuthToken, match="AUTH_TOKEN environment variable must be provided"):
         StagingServiceConfig(config_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+import pytest
+from pathlib import Path
+from configparser import ConfigParser
+from staging_service.config import StagingServiceConfig #, _get_value, _get_path_value
+
+VALID_CONFIG = """
+[staging_service]
+AUTH_URL = https://example.com/auth
+DATA_DIR = /kb/deployment/data
+META_DIR = /kb/deployment/data/meta
+CONCIERGE_PATH = /kb/deployment/concierge.json
+FILE_EXTENSION_MAPPINGS = ./mappings.json
+DTS_MANIFEST_SCHEMA = ./schema.json
+"""
+
+def write_config_file(config_dir: Path, content: str) -> str:
+    # writes out some content to "config.cfg" in the provided
+    # directory. Returns the path to the file as a string.
+    file = config_dir / "config.cfg"
+    file.write_text(content)
+    return str(file)
+
+def test_valid_config_parsing(tmp_path):
+    config_path = write_config_file(tmp_path, VALID_CONFIG)
+    config = StagingServiceConfig(config_path)
+
+    assert config.auth_url == "https://example.com/auth"
+    assert Path(config.data_dir).is_absolute()
+    assert config.data_dir.endswith("data")
+    assert config.meta_dir.endswith("meta")
+
+def test_missing_config_path():
+    with pytest.raises(ValueError, match="config_path is required"):
+        StagingServiceConfig("")
+
+def test_nonexistent_config_file():
+    with pytest.raises(FileNotFoundError):
+        StagingServiceConfig("nonexistent.ini")
+
+def test_missing_heading(tmp_path):
+    bad_config = "[wrong_section]\nfoo=bar"
+    config_path = write_config_file(tmp_path, bad_config)
+    with pytest.raises(ValueError, match="missing required section"):
+        StagingServiceConfig(config_path)
+
+def test_missing_required_key(tmp_path):
+    bad_config = "[staging_service]\nDATA_DIR=./data"
+    config_path = write_config_file(tmp_path, bad_config)
+    with pytest.raises(ValueError, match="Please provide AUTH_URL"):
+        StagingServiceConfig(config_path)
+
+def test_relative_path_resolution(tmp_path, monkeypatch):
+    config = ConfigParser()
+    config.add_section("staging_service")
+    config.set("staging_service", "DATA_DIR", "./relative_dir")
+    monkeypatch.chdir(tmp_path)
+    path = _get_path_value(config["staging_service"], "DATA_DIR")
+    assert Path(path) == tmp_path / "relative_dir"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,41 +1,59 @@
 import pytest
 from pathlib import Path
-from configparser import ConfigParser
-from staging_service.config import StagingServiceConfig #, _get_value, _get_path_value
+from staging_service.config import MissingAuthToken, StagingServiceConfig
+import os
 
-VALID_CONFIG = """
+# separate these for easier assertions
+AUTH_URL = "https://example.com/auth"
+DATA_DIR = "/kb/deployment/data/bulk"
+META_DIR = "/kb/deployment/data/metadata"
+CONCIERGE_PATH = "/kbaseconcierge"
+FILE_EXTENSION_MAPPINGS = "/kb/deployment/file_mappings.json"
+DTS_MANIFEST_SCHEMA = "/kb/deployment/dts_manifest_schema.json"
+
+VALID_CONFIG = f"""
 [staging_service]
-AUTH_URL = https://example.com/auth
-DATA_DIR = /kb/deployment/data
-META_DIR = /kb/deployment/data/meta
-CONCIERGE_PATH = /kb/deployment/concierge.json
-FILE_EXTENSION_MAPPINGS = ./mappings.json
-DTS_MANIFEST_SCHEMA = ./schema.json
+AUTH_URL = {AUTH_URL}
+DATA_DIR = {DATA_DIR}
+META_DIR = {META_DIR}
+CONCIERGE_PATH = {CONCIERGE_PATH}
+FILE_EXTENSION_MAPPINGS = {FILE_EXTENSION_MAPPINGS}
+DTS_MANIFEST_SCHEMA = {DTS_MANIFEST_SCHEMA}
 """
 
+
 def write_config_file(config_dir: Path, content: str) -> str:
-    # writes out some content to "config.cfg" in the provided
-    # directory. Returns the path to the file as a string.
+    """
+    Writes out some content to "config.cfg" in the provided
+    directory. Returns the path to the file as a string.
+    """
     file = config_dir / "config.cfg"
     file.write_text(content)
     return str(file)
 
-def test_valid_config_parsing(tmp_path):
+
+def test_valid_config(tmp_path):
     config_path = write_config_file(tmp_path, VALID_CONFIG)
     config = StagingServiceConfig(config_path)
 
-    assert config.auth_url == "https://example.com/auth"
-    assert Path(config.data_dir).is_absolute()
-    assert config.data_dir.endswith("data")
-    assert config.meta_dir.endswith("meta")
+    assert config.auth_url == AUTH_URL
+    assert config.data_dir == DATA_DIR
+    assert config.meta_dir == META_DIR
+    assert config.concierge_path == CONCIERGE_PATH
+    assert config.file_extension_mappings == FILE_EXTENSION_MAPPINGS
+    assert config.dts_manifest_schema == DTS_MANIFEST_SCHEMA
+    assert config.auth_token == os.environ["AUTH_TOKEN"]
+
 
 def test_missing_config_path():
     with pytest.raises(ValueError, match="config_path is required"):
         StagingServiceConfig("")
 
-def test_nonexistent_config_file():
+
+def test_missing_config_file():
     with pytest.raises(FileNotFoundError):
-        StagingServiceConfig("nonexistent.ini")
+        StagingServiceConfig("missing.cfg")
+
 
 def test_missing_heading(tmp_path):
     bad_config = "[wrong_section]\nfoo=bar"
@@ -43,16 +61,40 @@ def test_missing_heading(tmp_path):
     with pytest.raises(ValueError, match="missing required section"):
         StagingServiceConfig(config_path)
 
+
 def test_missing_required_key(tmp_path):
     bad_config = "[staging_service]\nDATA_DIR=./data"
     config_path = write_config_file(tmp_path, bad_config)
     with pytest.raises(ValueError, match="Please provide AUTH_URL"):
         StagingServiceConfig(config_path)
 
-def test_relative_path_resolution(tmp_path, monkeypatch):
-    config = ConfigParser()
-    config.add_section("staging_service")
-    config.set("staging_service", "DATA_DIR", "./relative_dir")
-    monkeypatch.chdir(tmp_path)
-    path = _get_path_value(config["staging_service"], "DATA_DIR")
-    assert Path(path) == tmp_path / "relative_dir"
+
+def test_path_resolution(tmp_path):
+    non_relative_config = f"""
+        [staging_service]
+        AUTH_URL = {AUTH_URL}
+        DATA_DIR = ./data
+        META_DIR = ./meta
+        CONCIERGE_PATH = ./concierge
+        FILE_EXTENSION_MAPPINGS = ./file_extension_mappings.json
+        DTS_MANIFEST_SCHEMA = ./dts_manifest_schema.json
+    """
+    config_path = write_config_file(tmp_path, non_relative_config)
+    config = StagingServiceConfig(config_path)
+    config_keys = [
+        "data_dir",
+        "meta_dir",
+        "concierge_path",
+        "file_extension_mappings",
+        "dts_manifest_schema",
+    ]
+    for key in config_keys:
+        value = getattr(config, key)
+        assert Path(value).is_absolute()
+
+
+def test_missing_auth_token(monkeypatch, tmp_path):
+    monkeypatch.delenv("AUTH_TOKEN")
+    config_path = write_config_file(tmp_path, VALID_CONFIG)
+    with pytest.raises(MissingAuthToken, match="AUTH_TOKEN environment variable must be provided"):
+        StagingServiceConfig(config_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,15 +11,20 @@ CONCIERGE_PATH = "/kbaseconcierge"
 FILE_EXTENSION_MAPPINGS = "/kb/deployment/file_mappings.json"
 DTS_MANIFEST_SCHEMA = "/kb/deployment/dts_manifest_schema.json"
 
-VALID_CONFIG = f"""
-[staging_service]
-AUTH_URL = {AUTH_URL}
-DATA_DIR = {DATA_DIR}
-META_DIR = {META_DIR}
-CONCIERGE_PATH = {CONCIERGE_PATH}
-FILE_EXTENSION_MAPPINGS = {FILE_EXTENSION_MAPPINGS}
-DTS_MANIFEST_SCHEMA = {DTS_MANIFEST_SCHEMA}
-"""
+VALID_HEADER = "[staging_service]"
+
+VALID_CONFIG_DICT = {
+    "AUTH_URL": AUTH_URL,
+    "DATA_DIR": DATA_DIR,
+    "META_DIR": META_DIR,
+    "CONCIERGE_PATH": CONCIERGE_PATH,
+    "FILE_EXTENSION_MAPPINGS": FILE_EXTENSION_MAPPINGS,
+    "DTS_MANIFEST_SCHEMA": DTS_MANIFEST_SCHEMA
+}
+
+
+def dummy_config(header: str, config_dict: dict[str, str]) -> str:
+    return header + "\n" + "\n".join([f"{k} = {v}" for k, v in config_dict.items()])
 
 
 def write_config_file(config_dir: Path, content: str) -> str:
@@ -33,7 +38,7 @@ def write_config_file(config_dir: Path, content: str) -> str:
 
 
 def test_valid_config(tmp_path):
-    config_path = write_config_file(tmp_path, VALID_CONFIG)
+    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, VALID_CONFIG_DICT))
     config = StagingServiceConfig(config_path)
 
     assert config.auth_url == AUTH_URL
@@ -51,21 +56,24 @@ def test_missing_config_path():
 
 
 def test_missing_config_file():
-    with pytest.raises(FileNotFoundError):
-        StagingServiceConfig("missing.cfg")
+    missing_file = "missing.cfg"
+    with pytest.raises(FileNotFoundError, match=f"config path {missing_file} does not exist"):
+        StagingServiceConfig(missing_file)
 
 
 def test_missing_heading(tmp_path):
     bad_config = "[wrong_section]\nfoo=bar"
     config_path = write_config_file(tmp_path, bad_config)
-    with pytest.raises(ValueError, match="missing required section"):
+    with pytest.raises(ValueError, match=f"config file {config_path} is missing required section {VALID_HEADER}"):
         StagingServiceConfig(config_path)
 
 
-def test_missing_required_key(tmp_path):
-    bad_config = "[staging_service]\nDATA_DIR=./data"
-    config_path = write_config_file(tmp_path, bad_config)
-    with pytest.raises(ValueError, match="Please provide AUTH_URL"):
+@pytest.mark.parametrize("missing_key", VALID_CONFIG_DICT.keys())
+def test_missing_required_key(tmp_path, missing_key):
+    missing_config_dict = VALID_CONFIG_DICT.copy()
+    del missing_config_dict[missing_key]
+    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, missing_config_dict))
+    with pytest.raises(ValueError, match=f"Please provide {missing_key} in the config file section {VALID_HEADER}"):
         StagingServiceConfig(config_path)
 
 
@@ -95,6 +103,6 @@ def test_path_resolution(tmp_path):
 
 def test_missing_auth_token(monkeypatch, tmp_path):
     monkeypatch.delenv("AUTH_TOKEN")
-    config_path = write_config_file(tmp_path, VALID_CONFIG)
+    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, VALID_CONFIG_DICT))
     with pytest.raises(MissingAuthToken, match="AUTH_TOKEN environment variable must be provided"):
         StagingServiceConfig(config_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,7 +116,8 @@ def test_missing_required_key(tmp_path, missing_key):
     del missing_config_dict[missing_key]
     config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, missing_config_dict))
     with pytest.raises(
-        ValueError, match=f"Config file {config_path} error: missing required key {missing_key} in section {VALID_HEADER}"
+        ValueError,
+        match=f"Config file {config_path} error: missing required key {missing_key} in section {VALID_HEADER}",
     ):
         StagingServiceConfig(config_path)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,8 @@ TEST_TOKEN = None
 TEST_USER = None
 AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
 
-VALID_HEADER = "[staging_service]"
+VALID_HEADER_NAME = "staging_service"
+VALID_HEADER = f"[{VALID_HEADER_NAME}]"
 
 DEFAULT_CONFIG_DICT = {
     "AUTH_URL": AUTH_URL,
@@ -105,7 +106,8 @@ def test_missing_heading(tmp_path):
     bad_config = "[wrong_section]\nfoo=bar"
     config_path = write_config_file(tmp_path, bad_config)
     with pytest.raises(
-        ValueError, match=f"Config file {config_path} is missing required section {VALID_HEADER}"
+        ValueError,
+        match=f"Config file {config_path} is missing required section {VALID_HEADER_NAME}",
     ):
         StagingServiceConfig(config_path)
 
@@ -117,7 +119,19 @@ def test_missing_required_key(tmp_path, missing_key):
     config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, missing_config_dict))
     with pytest.raises(
         ValueError,
-        match=f"Config file {config_path} error: missing required key {missing_key} in section {VALID_HEADER}",
+        match=f"Config file {config_path} error: missing required key {missing_key} in section {VALID_HEADER_NAME}",
+    ):
+        StagingServiceConfig(config_path)
+
+
+@pytest.mark.parametrize("whitespace_key", DEFAULT_CONFIG_DICT.keys())
+def test_whitespace_required_key(tmp_path, whitespace_key):
+    whitespace_config_dict = DEFAULT_CONFIG_DICT.copy()
+    whitespace_config_dict[whitespace_key] = "   "
+    config_path = write_config_file(tmp_path, dummy_config(VALID_HEADER, whitespace_config_dict))
+    with pytest.raises(
+        ValueError,
+        match=f"Config file {config_path} error: required key {whitespace_key} in section {VALID_HEADER_NAME} must not be empty or all whitespace",
     ):
         StagingServiceConfig(config_path)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ META_DIR = "/kb/deployment/data/metadata"
 CONCIERGE_PATH = "/kbaseconcierge"
 FILE_EXTENSION_MAPPINGS = "/kb/deployment/file_mappings.json"
 DTS_MANIFEST_SCHEMA = "/kb/deployment/dts_manifest_schema.json"
-# TODO update the below when config file templates are in place - issue #227
+# TODO update the below when config file templates are in place - issue #228
 TEST_TOKEN = None
 TEST_USER = None
 AUTH_TOKEN = os.environ.get("AUTH_TOKEN")

--- a/tests/test_kb_auth.py
+++ b/tests/test_kb_auth.py
@@ -2,19 +2,18 @@ import asyncio
 import pytest
 from staging_service.kb_auth_client import InvalidUserError, KBaseAuth, InvalidTokenError, _get
 from tests.test_utils import bootstrap_config
-import os
 from unittest.mock import patch
 
-AUTH_URL = bootstrap_config().auth_url
+CONFIG = bootstrap_config()
+AUTH_URL = CONFIG.auth_url
+TEST_TOKEN = CONFIG.test_token
+TEST_USER = CONFIG.test_user
 
 # NOTE: These tests are intended to be run against the auth service at
 # https://ci.kbase.us/services/auth
 # Any unexpected failures should check the auth service, the given test
 # token, and whether the test user exists or not.
 
-# TODO: add env var names to test config
-TEST_TOKEN = os.environ.get("KBASE_TEST_TOKEN")
-TEST_USER = os.environ.get("KBASE_TEST_USER")
 VALID_TEST_USER = "narrativetest"
 NOT_REAL_USER = "please_do_not_ever_make_this_username_what_is_wrong_with_you"
 INVALID_USER = "_(__)_"

--- a/tests/test_kb_auth.py
+++ b/tests/test_kb_auth.py
@@ -3,11 +3,15 @@ import pytest
 from staging_service.kb_auth_client import InvalidUserError, KBaseAuth, InvalidTokenError, _get
 from tests.test_utils import bootstrap_config
 from unittest.mock import patch
+import os
 
 CONFIG = bootstrap_config()
 AUTH_URL = CONFIG.auth_url
-TEST_TOKEN = CONFIG.test_token
-TEST_USER = CONFIG.test_user
+# TODO: temporary until config is templated, then update to
+# CONFIG.test_token, CONFIG.test_user
+# see github issue 228: https://github.com/kbase/staging_service/issues/228
+TEST_TOKEN = os.environ.get("KBASE_TEST_TOKEN")
+TEST_USER = os.environ.get("KBASE_TEST_USER")
 
 # NOTE: These tests are intended to be run against the auth service at
 # https://ci.kbase.us/services/auth

--- a/tests/test_kb_auth.py
+++ b/tests/test_kb_auth.py
@@ -5,8 +5,7 @@ from tests.test_utils import bootstrap_config
 import os
 from unittest.mock import patch
 
-config = bootstrap_config()
-AUTH_URL = config.auth_url
+AUTH_URL = bootstrap_config().auth_url
 
 # NOTE: These tests are intended to be run against the auth service at
 # https://ci.kbase.us/services/auth

--- a/tests/test_kb_auth.py
+++ b/tests/test_kb_auth.py
@@ -7,9 +7,6 @@ import os
 
 CONFIG = bootstrap_config()
 AUTH_URL = CONFIG.auth_url
-# TODO: temporary until config is templated, then update to
-# CONFIG.test_token, CONFIG.test_user
-# see github issue 228: https://github.com/kbase/staging_service/issues/228
 TEST_TOKEN = os.environ.get("KBASE_TEST_TOKEN")
 TEST_USER = os.environ.get("KBASE_TEST_USER")
 

--- a/tests/test_kb_auth.py
+++ b/tests/test_kb_auth.py
@@ -6,7 +6,7 @@ import os
 from unittest.mock import patch
 
 config = bootstrap_config()
-AUTH_URL = config["staging_service"]["AUTH_URL"]
+AUTH_URL = config.auth_url
 
 # NOTE: These tests are intended to be run against the auth service at
 # https://ci.kbase.us/services/auth

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,8 @@ from typing import Any
 import openpyxl
 from dotenv import load_dotenv
 
+from staging_service.config import StagingServiceConfig
+
 
 def bootstrap():
     test_env_0 = "../test.env"
@@ -26,8 +28,7 @@ def bootstrap_config():
     if not os.path.exists(config_filepath):
         raise FileNotFoundError(config_filepath)
 
-    config = configparser.ConfigParser()
-    config.read(config_filepath)
+    config = StagingServiceConfig(config_filepath)
     return config
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-import configparser
 import os
 import traceback
 from pathlib import Path


### PR DESCRIPTION
This does a few things around config. I'm trying not to do too much in this first step.

1. Add a StagingServiceConfig object that does the job of parsing the config file.
2. Incorporate the new config object in the main webapp.
3. Add a service token as an `AUTH_TOKEN` environment variable.

This does not undo the config injection into global objects or anything like that yet. I'm just starting with making the config object and getting the service token in.

A later PR (probably not the next one) will undo the config injection things.