### PR TITLE
remove file-lifetime endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,7 @@
             "args": [],
             //note the setting of env should be the same as entrypoint.sh
             "env": {
-                "KB_DEPLOYMENT_CONFIG":"${workspaceRoot}/deployment/conf/local.cfg",
-                "FILE_LIFETIME":90
+                "KB_DEPLOYMENT_CONFIG":"${workspaceRoot}/deployment/conf/local.cfg"
             },
             "envFile": "${workspaceRoot}/.env",
             "debugOptions": [
@@ -38,8 +37,7 @@
             "cwd": "${workspaceRoot}",
             //note the setting of env should be the same as entrypoint.sh
             "env": {
-                "KB_DEPLOYMENT_CONFIG":"${workspaceRoot}/deployment/conf/testing.cfg",
-                "FILE_LIFETIME":90
+                "KB_DEPLOYMENT_CONFIG":"${workspaceRoot}/deployment/conf/testing.cfg"
             },
             "envFile": "${workspaceRoot}/.env",
             "debugOptions": [

--- a/README.md
+++ b/README.md
@@ -124,26 +124,6 @@ Error Connecting to auth service ...
 Must supply token
 ```
 
-### File Lifetime
-
-**URL** : `ci.kbase.us/services/staging_service/file-lifetime`
-**local URL** : `localhost:3000/file-lifetime`
-
-**Method** : `GET`
-
-#### Success Response
-
-**Code** : `200 OK`
-
-**Content example**
-number of days a file will be held for in staging service before being deleted
-this is not actually handled by the server but is expected to be performed by a
-cron job which shares the env variable read here
-
-```
-90
-```
-
 ### List Directory
 
 defaults to not show hidden dotfiles

--- a/deployment/bin/entrypoint.sh
+++ b/deployment/bin/entrypoint.sh
@@ -8,7 +8,6 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 if [ -d "$DIR/../../staging_service" ]; then
     PYTHONPATH="$DIR/../../staging_service"
     export KB_DEPLOYMENT_CONFIG="$DIR/../conf/local.cfg"
-    export FILE_LIFETIME="90"
 fi
 
 #bottom section for running inside docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,5 @@ services:
       - "./:/staging_service"
     environment:
       KB_DEPLOYMENT_CONFIG: /kb/deployment/conf/deployment.cfg
-      FILE_LIFETIME: "90"
       # This is the expected service token. Modify this so it's real for the environment.
       AUTH_TOKEN: fake_token

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 export KB_DEPLOYMENT_CONFIG="$DIR/deployment/conf/testing.cfg"
-export FILE_LIFETIME="90"
 export TESTS="${1:-tests}"
 export AUTH_TOKEN="fake_token"
 echo

--- a/staging_service/app.py
+++ b/staging_service/app.py
@@ -282,11 +282,6 @@ async def test_auth(request: web.Request):
     return web.Response(text=f"I'm authenticated as {username}")
 
 
-@routes.get("/file-lifetime")
-async def file_lifetime(_: web.Request):
-    return web.Response(text=os.environ["FILE_LIFETIME"])
-
-
 @routes.get("/existence/{query:.*}")
 async def file_exists(request: web.Request):
     username = await authorize_request(request)


### PR DESCRIPTION
See #229 

Highlights:
The `FILE_LIFETIME` env var is the only one not in the config file. My goal was to put it there. Along the way I found:
* `FILE_LIFETIME` is really only used in the `file-lifetime` endpoint, which just coughs it up to the user (without any validation of its presence, I might add).
* Nothing in KBase uses it. (or the kbaseapps or kbaseincubator orgs, for that matter).
* It's not actually linked to anything that actually tracks the file lifetime on the filesystem.
* That endpoint isn't even covered by tests.

So instead of updating the config to use it, we're removing that endpoint.

Fixes #229 