### PR TITLE
Add heartbeat and health check to DTSFileWatcher

### DIFF
--- a/staging_service/dts_file_watcher.py
+++ b/staging_service/dts_file_watcher.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+import time
 import traceback
 import aiofiles
 import asyncio
@@ -23,6 +25,17 @@ STABLE_TIME = 2.0
 WAIT_FOR_FILE_LIMIT = 5
 WATCHFILES_POLL_DELAY_MS = 500
 WATCHFILES_FORCE_POLLING = True
+HEALTH_CHECK_TIMEOUT_SEC = 60
+
+
+@dataclass
+class DTSWatcherHealth:
+    is_watching: bool
+    last_heartbeat: int
+    time_since_heartbeat: int
+    is_healthy: bool
+    watch_directory: str
+    health_check_timeout: int
 
 
 class DTSFileWatcher:
@@ -44,6 +57,8 @@ class DTSFileWatcher:
         self._config = config
         # the watcher listens for this on each loop, and stops when it's set.
         self._stop_event = asyncio.Event()
+        self._last_heartbeat = time.time()
+        self._is_watching = False
 
     async def start_watching_for_files(self) -> None:
         """
@@ -71,6 +86,8 @@ class DTSFileWatcher:
             raise FileNotFoundError(err_str)
 
         logger.info(f"watching dir {self._watch_dir} for DTS manifest files.")
+        self._is_watching = True
+        self._last_heartbeat = time.time()
 
         async for changes in awatch(
             self._watch_dir,
@@ -80,6 +97,9 @@ class DTSFileWatcher:
             stop_event=self._stop_event,
             yield_on_timeout=True,
         ):
+            # update heartbeat on loop iteration, including timeouts
+            self._last_heartbeat = time.time()
+
             for change_type, change_file_path in changes:
                 file_path = Path(change_file_path)
                 # manifest file must be in a subdirectory to be detected
@@ -100,12 +120,32 @@ class DTSFileWatcher:
                     except Exception as e:
                         # Not sure how else this can fail, but just in case...
                         logger.error(f"Unexpected error: {e}\n{traceback.format_exc()}")
+        self._is_watching = False
         logger.info(
             f"Stop event triggered, no longer watching {self._watch_dir} for DTS manifest files."
         )
 
     def stop_watching_for_files(self) -> None:
         self._stop_event.set()
+
+    def is_healthy(self) -> bool:
+        """
+        Check if the file watcher is healthy.
+        Returns True if:
+        1. The watcher is currently watching
+        2. The last heartbeat was within the timeout period
+        """
+        return self._is_watching and time.time() - self._last_heartbeat <= HEALTH_CHECK_TIMEOUT_SEC
+
+    def get_health_status(self) -> DTSWatcherHealth:
+        return DTSWatcherHealth(
+            self._is_watching,
+            self._last_heartbeat,
+            time.time() - self._last_heartbeat,
+            self.is_healthy(),
+            str(self._watch_dir),
+            HEALTH_CHECK_TIMEOUT_SEC,
+        )
 
     async def _process_complete_manifest(self, manifest_path: Path):
         """

--- a/staging_service/dts_file_watcher.py
+++ b/staging_service/dts_file_watcher.py
@@ -25,17 +25,17 @@ STABLE_TIME = 2.0
 WAIT_FOR_FILE_LIMIT = 5
 WATCHFILES_POLL_DELAY_MS = 500
 WATCHFILES_FORCE_POLLING = True
-HEALTH_CHECK_TIMEOUT_SEC = 60
+HEALTH_CHECK_TIMEOUT_SEC = 60.0
 
 
 @dataclass
 class DTSWatcherHealth:
     is_watching: bool
-    last_heartbeat: int
-    time_since_heartbeat: int
+    last_heartbeat: float
+    time_since_heartbeat: float
     is_healthy: bool
     watch_directory: str
-    health_check_timeout: int
+    health_check_timeout: float
 
 
 class DTSFileWatcher:

--- a/tests/test_dts_file_watcher.py
+++ b/tests/test_dts_file_watcher.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 from typing import Callable, Tuple
 import aiofiles
 import pytest
@@ -11,7 +12,9 @@ from staging_service.dts_file_watcher import (
     WAIT_INTERVAL_SEC,
     DTSFileWatcher,
     LOGGER_NAME,
+    DTSWatcherHealth,
     MoveDtsFilesError,
+    HEALTH_CHECK_TIMEOUT_SEC,
 )
 from pathlib import Path
 from watchfiles import Change
@@ -347,3 +350,171 @@ async def test_dts_watcher_end_to_end_duplicate_path(config_tmp_path, caplog, au
                     assert test_data == manifest_text
                 else:
                     assert test_data == f"my name is {item.name}"
+
+
+def assert_watcher_health(
+    health_status: DTSWatcherHealth,
+    is_healthy: bool = True,
+    is_watching: bool = True,
+    config_dir: str = None,
+):
+    assert health_status.is_healthy == is_healthy
+    assert health_status.is_watching == is_watching
+    assert health_status.time_since_heartbeat >= 0
+    assert health_status.watch_directory == config_dir
+    assert health_status.health_check_timeout == HEALTH_CHECK_TIMEOUT_SEC
+    assert health_status.time_since_heartbeat >= 0
+
+
+def test_initial_health(config_tmp_path, auth_client):
+    """Test that watcher starts with proper initial heartbeat state."""
+    # Before starting, should not be watching and not healthy
+    watcher = DTSFileWatcher(auth_client, config_tmp_path)
+    assert not watcher._is_watching
+    assert not watcher.is_healthy()
+
+    health_status = watcher.get_health_status()
+    assert_watcher_health(
+        health_status,
+        is_healthy=False,
+        is_watching=False,
+        config_dir=str(config_tmp_path.dts_staging_dir),
+    )
+
+
+async def test_heartbeat_updates_during_watching(config_tmp_path, auth_client):
+    """Test that heartbeat updates when watcher is active."""
+    watcher = DTSFileWatcher(auth_client, config_tmp_path)
+    initial_heartbeat = watcher._last_heartbeat
+
+    await _run_watcher_once(watcher, wait_time=5)
+
+    health = watcher.get_health_status()
+    assert health.last_heartbeat > initial_heartbeat
+
+    # Should be unhealthy once stopped
+    assert not watcher.is_healthy()
+    health = watcher.get_health_status()
+    assert_watcher_health(
+        health, is_healthy=False, is_watching=False, config_dir=str(config_tmp_path.dts_staging_dir)
+    )
+
+
+async def test_watching_state_changes(config_tmp_path, auth_client):
+    watcher = DTSFileWatcher(auth_client, config_tmp_path)
+    assert not watcher._is_watching
+
+    with patch("staging_service.dts_file_watcher.awatch") as mock_awatch:
+
+        async def mocked_events_generator():
+            assert watcher._is_watching
+            assert_watcher_health(
+                watcher.get_health_status(), config_dir=str(config_tmp_path.dts_staging_dir)
+            )
+            watcher.stop_watching_for_files()
+            yield []
+
+        mock_awatch.return_value = mocked_events_generator()
+
+        await watcher.start_watching_for_files()
+        assert not watcher._is_watching
+
+
+async def test_heartbeat_updates_on_timeout_iterations(auth_client, config_tmp_path):
+    """Test that heartbeat updates even when awatch yields due to timeout."""
+    heartbeats = []
+    watcher = DTSFileWatcher(auth_client, config_tmp_path)
+
+    with patch("staging_service.dts_file_watcher.awatch") as mock_awatch:
+
+        async def mock_generator():
+            # Record heartbeat before each yield
+            heartbeats.append(watcher._last_heartbeat)
+            yield []  # Empty changes (timeout case)
+
+            # Small delay to ensure time difference
+            await asyncio.sleep(0.01)
+            heartbeats.append(watcher._last_heartbeat)
+            yield []  # Another empty yield
+
+            # Stop the watcher
+            watcher._stop_event.set()
+
+        mock_awatch.return_value = mock_generator()
+
+        await watcher.start_watching_for_files()
+
+        # Should have multiple heartbeat updates
+        assert len(heartbeats) == 2
+        assert heartbeats[1] > heartbeats[0]
+
+
+async def test_health_check_during_file_processing(auth_client, config_tmp_path):
+    """Test that heartbeat continues updating even during file processing."""
+    watcher = DTSFileWatcher(auth_client, config_tmp_path)
+    # Create a test manifest file
+    test_dir = config_tmp_path.dts_staging_dir / "test_transfer"
+    test_dir.mkdir()
+    manifest_file = test_dir / "manifest.json"
+
+    with patch("staging_service.dts_file_watcher.awatch") as mock_awatch:
+        with patch.object(watcher, "_process_complete_manifest") as mock_process:
+            # Make file processing take some time
+            async def slow_process(path):
+                await asyncio.sleep(0.1)
+                # Verify heartbeat is still being updated during processing
+                assert watcher.is_healthy()
+
+            mock_process.side_effect = slow_process
+
+            async def mock_generator():
+                # Simulate file creation event
+                yield [(Change.added, str(manifest_file))]
+                watcher._stop_event.set()
+
+            mock_awatch.return_value = mock_generator()
+
+            await watcher.start_watching_for_files()
+
+            # Process should have been called
+            mock_process.assert_called_once_with(manifest_file)
+
+
+def test_health_check_boundary_conditions(auth_client, config_tmp_path):
+    """Test health check at exact timeout boundary."""
+    watcher = DTSFileWatcher(auth_client, config_tmp_path)
+    watcher._is_watching = True
+
+    # Test exactly at timeout boundary
+    watcher._last_heartbeat = time.time() - HEALTH_CHECK_TIMEOUT_SEC
+    # Due to floating point precision, this might be healthy or not
+    # Just verify it's consistent with the calculation
+    assert watcher.is_healthy() == (
+        watcher.get_health_status().time_since_heartbeat < HEALTH_CHECK_TIMEOUT_SEC
+    )
+
+    # Test just over timeout
+    watcher._last_heartbeat = time.time() - (HEALTH_CHECK_TIMEOUT_SEC + 0.1)
+    assert not watcher.is_healthy()
+
+    # Test just under timeout
+    watcher._last_heartbeat = time.time() - (HEALTH_CHECK_TIMEOUT_SEC - 0.1)
+    assert watcher.is_healthy()
+
+
+async def test_concurrent_health_checks(auth_client, config_tmp_path):
+    """Test that concurrent health checks work correctly."""
+    watcher = DTSFileWatcher(auth_client, config_tmp_path)
+    watcher._is_watching = True
+    watcher._last_heartbeat = time.time()
+
+    # Run multiple health checks concurrently
+    async def check_health():
+        await asyncio.sleep(0.01)  # Small delay
+        return watcher.is_healthy()
+
+    tasks = [check_health() for _ in range(10)]
+    results = await asyncio.gather(*tasks)
+
+    # All should return True since watcher is healthy
+    assert all(results)

--- a/tests/test_dts_file_watcher.py
+++ b/tests/test_dts_file_watcher.py
@@ -363,7 +363,6 @@ def assert_watcher_health(
     assert health_status.time_since_heartbeat >= 0
     assert health_status.watch_directory == config_dir
     assert health_status.health_check_timeout == HEALTH_CHECK_TIMEOUT_SEC
-    assert health_status.time_since_heartbeat >= 0
 
 
 def test_initial_health(config_tmp_path, auth_client):


### PR DESCRIPTION
There's two versions of the health check.
1. a simple "is_healthy" function - returns True if the process is running and returned a heartbeat before the last timeout
2. a more complex get_health_status function that returns a data packet with detailed heartbeat info and a bit of config for convenience - how long the timeout is, and what directory to monitor.