### PR TITLE
Update globus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cacheout==0.16.0
 coverage==7.2.7
 defusedxml==0.7.1
 frozendict==2.3.8
-globus-sdk==1.6.1
+globus-sdk==3.62.0
 hypothesis==6.136.1
 jsonschema==4.23.0
 openpyxl==3.1.2


### PR DESCRIPTION
# Fix for upgrade of python to 3.11
```
ERROR:aiohttp.server:Error handling request

Traceback (most recent call last):

  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 433, in _handle_request

    resp = await request_handler(request)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_app.py", line 504, in _handle

    resp = await handler(request)

           ^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_middlewares.py", line 117, in impl

    return await handler(request)

           ^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_middlewares.py", line 108, in impl

    return await handler(request)

           ^^^^^^^^^^^^^^^^^^^^^^

  File "/kb/deployment/lib/staging_service/app.py", line 262, in add_acl

    result = AclManager().add_acl(user_dir)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/kb/deployment/lib/staging_service/utils.py", line 264, in add_acl

    user_identity_id = self._get_globus_identity(shared_directory)

                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/kb/deployment/lib/staging_service/utils.py", line 127, in _get_globus_identity

    return self._get_globus_identities(globus_id_filename)["identities"][0]["id"]

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/kb/deployment/lib/staging_service/utils.py", line 120, in _get_globus_identities

    return self.globus_auth_client.get_identities(usernames=ident.split("\n")[0])

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/site-packages/globus_sdk/auth/client_types/base.py", line 147, in get_identities

    params["usernames"] = _convert_listarg(usernames)

                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/site-packages/globus_sdk/auth/client_types/base.py", line 133, in _convert_listarg

    if isinstance(val, collections.Iterable) and not isinstance(
```



# Temporary fix for Python 3.10+ compatibility with older globus-sdk versions
import collections.abc
import collections
collections.Iterable = collections.abc.Iterable
collections.Mapping = collections.abc.Mapping
collections.MutableMapping = collections.abc.MutableMapping
collections.Sequence = collections.abc.Sequence
collections.MutableSequence = collections.abc.MutableSequence

That worked.

# Testing
* Create .globus_cfg
* Download /etc/globus.cfg
* Run
```
# Manually an an ACL
# Attempt to add an ACL
if __name__ == "__main__":
    logging.basicConfig(
        format="%(asctime)s %(levelname)-8s %(message)s",
        level=logging.INFO,
        datefmt="%Y-%m-%d %H:%M:%S",
    )
    am = AclManager()

    id_file = "/Users/<username>/modules/staging_service/"


    # Try Removing ACL first


    response = am.remove_acl(id_file)
    print("Response: {}".format(response))


    print("Adding ACL for user in file: {}".format(id_file))
    try:
        response = am.add_acl(id_file)
        print("Response: {}".format(response))
    except HTTPInternalServerError as e:
        print("Error adding ACL: {}".format(e.text))
```
